### PR TITLE
fix: load font awesome for navigation icons

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -39,6 +39,14 @@ export const viewport: Viewport = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
     return (
         <html lang="en">
+            <head>
+                <link
+                    rel="stylesheet"
+                    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css"
+                    crossOrigin="anonymous"
+                    referrerPolicy="no-referrer"
+                />
+            </head>
             <body className="bg-gray-50 font-sans antialiased dark:bg-gray-900 transition-colors duration-300">
                 {children}
                 <Analytics />


### PR DESCRIPTION
## Summary
- load Font Awesome stylesheet in root layout so menu icons display

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7382f49f48329bf925a07e72e1aa3