### PR TITLE
Link Visit Us and Directions buttons to map section

### DIFF
--- a/components/GoogleBusinessIntegration.tsx
+++ b/components/GoogleBusinessIntegration.tsx
@@ -43,7 +43,7 @@ function GoogleBusinessIntegration() {
     ]
 
     return (
-        <div className="bg-white py-12 dark:bg-gray-800">
+        <section id="location" className="bg-white py-12 dark:bg-gray-800">
             <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
                 <div className="mb-10 lg:text-center">
                     <h2 className="text-2xl font-semibold uppercase tracking-wide text-green-600 dark:text-green-400">
@@ -148,7 +148,7 @@ function GoogleBusinessIntegration() {
                     </div>
                 </div>
             </div>
-        </div>
+        </section>
     )
 }
 


### PR DESCRIPTION
## Summary
- Add `id="location"` to GoogleBusinessIntegration so Visit Us and Directions buttons scroll to the Find Us on Google Maps section

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa68f8ede083299b930ccee474a05f