### PR TITLE
feat: remove search overlay backdrop

### DIFF
--- a/components/SearchNavigation.tsx
+++ b/components/SearchNavigation.tsx
@@ -176,7 +176,7 @@ function SearchNavigation({ products = [] }: { products: Product[] }) {
 
             {/* Search Overlay */}
             {isOpen && (
-                <div className="fixed inset-0 z-50 flex items-start justify-center bg-black bg-opacity-50 pt-20">
+                <div className="fixed inset-0 z-50 flex items-start justify-center pt-20">
                     <div className="mx-4 w-full max-w-2xl rounded-lg bg-white shadow-xl dark:bg-gray-800">
                         {/* Search Input */}
                         <div className="border-b border-gray-200 p-4 dark:border-gray-700">


### PR DESCRIPTION
## Summary
- remove dark backdrop from search overlay to keep page visible when search is open

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aaa579aa1c8329ab036882aa43fd7e