### PR TITLE
Improve button and navigation contrast

### DIFF
--- a/components/AboutSection.tsx
+++ b/components/AboutSection.tsx
@@ -12,7 +12,7 @@ export default function AboutSection() {
                             We&apos;re committed to providing high-quality, lab-tested hemp products that meet the highest standards of purity and potency.
                         </p>
                         <div className="mt-8">
-                            <a href="#location" className="inline-flex items-center rounded-lg bg-green-600 px-6 py-3 font-medium text-white hover:bg-green-700">
+                            <a href="#location" className="inline-flex items-center rounded-lg bg-green-700 px-6 py-3 font-medium text-white hover:bg-green-800">
                                 <i className="fas fa-map-marker-alt mr-2" /> Visit Our Store
                             </a>
                         </div>

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -243,8 +243,8 @@ function Navigation({ products = [] }: { products: Product[] }) {
                                             }
                                             className={`flex items-center rounded-md px-3 py-2 text-sm font-medium transition-colors duration-200 ${
                                                 activeSection === item.id
-                                                    ? 'bg-green-600 text-white'
-                                                    : 'text-gray-700 hover:bg-green-50 hover:text-green-600 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-green-400'
+                                                    ? 'bg-green-700 text-white'
+                                                    : 'text-gray-700 hover:bg-green-100 hover:text-green-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-green-300'
                                             }`}
                                         >
                                             <i
@@ -299,7 +299,7 @@ function Navigation({ products = [] }: { products: Product[] }) {
                                                                             item.id
                                                                         )
                                                                     }
-                                                                    className="block px-4 py-2 text-black dark:text-gray-300 hover:bg-green-50 hover:text-green-600 dark:hover:bg-gray-700 dark:hover:text-green-400"
+                                                                    className="block px-4 py-2 text-black dark:text-gray-300 hover:bg-green-100 hover:text-green-700 dark:hover:bg-gray-700 dark:hover:text-green-300"
                                                                     role="menuitem"
                                                                 >
                                                                     {
@@ -369,7 +369,7 @@ function Navigation({ products = [] }: { products: Product[] }) {
                                 onClick={toggleMenu}
                                 aria-expanded={isMenuOpen}
                                 aria-controls="mobile-menu"
-                                className="inline-flex items-center justify-center rounded-md p-2 text-gray-700 hover:bg-green-50 hover:text-green-600 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-green-500 md:hidden dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-green-400"
+                                className="inline-flex items-center justify-center rounded-md p-2 text-gray-700 hover:bg-green-100 hover:text-green-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-green-500 md:hidden dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-green-300"
                             >
                                 <span className="sr-only">{isMenuOpen ? 'Close main menu' : 'Open main menu'}</span>
                                 <i
@@ -410,8 +410,8 @@ function Navigation({ products = [] }: { products: Product[] }) {
                                         }
                                         className={`flex items-center rounded-md px-3 py-2 text-base font-medium transition-colors ${
                                             activeSection === item.id
-                                                ? 'bg-green-600 text-white'
-                                                : 'text-gray-700 hover:bg-green-50 hover:text-green-600 dark:text-gray-300 dark:hover:bg-gray-700'
+                                                ? 'bg-green-700 text-white'
+                                                  : 'text-gray-700 hover:bg-green-100 hover:text-green-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-green-300'
                                         }`}
                                     >
                                         <i


### PR DESCRIPTION
## Summary
- Use darker green backgrounds for active navigation items and hover states to boost contrast
- Adjust "Visit Our Store" button styling for better color accessibility

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aac88d550483298c619ba3e84ab1ba