### PR TITLE
Add dynamic canonical URLs

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,11 @@
 import './globals.css'
 import { Metadata } from 'next'
+import { headers } from 'next/headers'
 import { Analytics } from "@vercel/analytics/next"
 import { SpeedInsights } from '@vercel/speed-insights/next'
 import type { Viewport } from 'next'
 
-export const metadata: Metadata = {
+const baseMetadata: Metadata = {
     title: 'Route 66 Hemp - Premium Hemp Products | St Robert, MO',
     description: 'Premium hemp products in St Robert, Missouri. Quality CBD flower, concentrates, and vapes. Serving Pulaski County and Fort Leonard Wood area.',
     keywords: [
@@ -28,6 +29,18 @@ export const metadata: Metadata = {
         apple: '/apple-touch-icon.png',
     },
     authors: [{ name: 'Christopher Gibbons', url: 'mailto:route66hemp@gmail.com' }],
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+    const headersList = await headers()
+    const path = headersList.get('next-url') || '/'
+    const pathname = path.split('?')[0]
+    return {
+        ...baseMetadata,
+        alternates: {
+            canonical: `https://route66hemp.com${pathname}`,
+        },
+    }
 }
 
 export const viewport: Viewport = {


### PR DESCRIPTION
## Summary
- add dynamic `<link rel="canonical">` generation in root layout
- ensure canonical URLs use `https://route66hemp.com` with the current pathname

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aae769eee48329a23ba464cc05598b