### PR TITLE
Add canonical link tag for all pages

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Metadata } from 'next'
 import { Analytics } from "@vercel/analytics/next"
 import { SpeedInsights } from '@vercel/speed-insights/next'
 import type { Viewport } from 'next'
+import CanonicalUrl from '@/components/CanonicalUrl'
 
 export const metadata: Metadata = {
     title: 'Route 66 Hemp - Premium Hemp Products | St Robert, MO',
@@ -46,6 +47,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                     crossOrigin="anonymous"
                     referrerPolicy="no-referrer"
                 />
+                <CanonicalUrl />
             </head>
             <body className="bg-gray-50 font-sans antialiased dark:bg-gray-900 transition-colors duration-300">
                 {children}

--- a/components/CanonicalUrl.tsx
+++ b/components/CanonicalUrl.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+
+export default function CanonicalUrl() {
+    const pathname = usePathname()
+    const canonicalUrl = `https://route66hemp.com${pathname}`
+    return <link rel="canonical" href={canonicalUrl} />
+}


### PR DESCRIPTION
## Summary
- add CanonicalUrl component that generates an absolute HTTPS canonical link based on the current path
- include CanonicalUrl in the root layout head so every page has an authoritative URL

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aae769eee48329a23ba464cc05598b