### PR TITLE
Fix footer policy links causing redirect loop

### DIFF
--- a/components/FooterNavigation.tsx
+++ b/components/FooterNavigation.tsx
@@ -47,15 +47,15 @@ function FooterNavigation() {
             links: [
                 {
                     label: 'Privacy Policy',
-                    href: '/privacy-policy.html',
+                    href: '/privacy-policy/',
                 },
                 {
                     label: 'Terms of Service',
-                    href: '/terms-of-service.html',
+                    href: '/terms-of-service/',
                 },
                 {
                     label: 'Cookie Policy',
-                    href: '/cookie-policy.html',
+                    href: '/cookie-policy/',
                 },
             ],
         },

--- a/public/cookie-policy/index.html
+++ b/public/cookie-policy/index.html
@@ -13,7 +13,7 @@
             gtag('config', 'G-RGSJT8T1EF');
         </script>
         <title>Cookie Policy - Route 66 Hemp</title>
-        <link href="globals.css" rel="stylesheet">
+        <link href="/globals.css" rel="stylesheet">
     </head>
     <body class="bg-white text-gray-800 dark:bg-gray-900 dark:text-white">
         <main class="mx-auto max-w-4xl p-4">

--- a/public/privacy-policy/index.html
+++ b/public/privacy-policy/index.html
@@ -13,7 +13,7 @@
             gtag('config', 'G-RGSJT8T1EF');
         </script>
         <title>Privacy Policy - Route 66 Hemp</title>
-        <link href="globals.css" rel="stylesheet" />
+        <link href="/globals.css" rel="stylesheet" />
     </head>
     <body class="bg-white text-gray-800 dark:bg-gray-900 dark:text-white">
         <main class="mx-auto max-w-4xl p-4">

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -9,9 +9,10 @@ Allow: /
 Allow: /products
 Allow: /about
 Allow: /contact
-Allow: /privacy-policy.html
-Allow: /terms-of-service.html
+Allow: /privacy-policy/
+Allow: /terms-of-service/
+Allow: /cookie-policy/
 
 # Block access to development files
 Disallow: /*.json$
-Disallow: /node_modules/
+Disallow: /node_modules

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -13,17 +13,24 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://route66hemp.com/privacy-policy.html</loc>
+    <loc>https://route66hemp.com/privacy-policy/</loc>
     <lastmod>2025-01-27</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
-  
+
   <url>
-    <loc>https://route66hemp.com/terms-of-service.html</loc>
+    <loc>https://route66hemp.com/terms-of-service/</loc>
     <lastmod>2025-01-27</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
-  
+
+  <url>
+    <loc>https://route66hemp.com/cookie-policy/</loc>
+    <lastmod>2025-01-27</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+
 </urlset>

--- a/public/terms-of-service/index.html
+++ b/public/terms-of-service/index.html
@@ -13,7 +13,7 @@
             gtag('config', 'G-RGSJT8T1EF');
         </script>
         <title>Terms of Service - Route 66 Hemp</title>
-        <link href="globals.css" rel="stylesheet" />
+        <link href="/globals.css" rel="stylesheet" />
     </head>
     <body class="auto-contrast bg-white text-gray-800 dark:bg-gray-900 dark:text-white">
         <main class="mx-auto max-w-4xl p-4">
@@ -28,7 +28,7 @@
             <h2 class="mb-2 mt-6 text-2xl font-semibold">Privacy</h2>
             <p class="mb-4">
                 Our
-                <a href="privacy-policy.html" class="text-blue-600 underline"
+                <a href="/privacy-policy/" class="text-blue-600 underline"
                     >Privacy Policy</a
                 >
                 describes how we collect, use, and share your information. By


### PR DESCRIPTION
## Summary
- Serve legal policy pages from directory index files to honor Vercel clean URLs
- Update footer links and robot/sitemap entries to point to new policy routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aaf4cdd3bc8329848d9ece95c02403