### PR TITLE
fix: update policy links to correct paths

### DIFF
--- a/components/FooterNavigation.tsx
+++ b/components/FooterNavigation.tsx
@@ -47,15 +47,15 @@ function FooterNavigation() {
             links: [
                 {
                     label: 'Privacy Policy',
-                    href: '/privacy-policy/',
+                    href: '/privacy-policy/index.html',
                 },
                 {
                     label: 'Terms of Service',
-                    href: '/terms-of-service/',
+                    href: '/terms-of-service/index.html',
                 },
                 {
                     label: 'Cookie Policy',
-                    href: '/cookie-policy/',
+                    href: '/cookie-policy/index.html',
                 },
             ],
         },

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -9,9 +9,9 @@ Allow: /
 Allow: /products
 Allow: /about
 Allow: /contact
-Allow: /privacy-policy/
-Allow: /terms-of-service/
-Allow: /cookie-policy/
+Allow: /privacy-policy/index.html
+Allow: /terms-of-service/index.html
+Allow: /cookie-policy/index.html
 
 # Block access to development files
 Disallow: /*.json$

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -13,21 +13,21 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://route66hemp.com/privacy-policy/</loc>
+    <loc>https://route66hemp.com/privacy-policy/index.html</loc>
     <lastmod>2025-01-27</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
 
   <url>
-    <loc>https://route66hemp.com/terms-of-service/</loc>
+    <loc>https://route66hemp.com/terms-of-service/index.html</loc>
     <lastmod>2025-01-27</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
 
   <url>
-    <loc>https://route66hemp.com/cookie-policy/</loc>
+    <loc>https://route66hemp.com/cookie-policy/index.html</loc>
     <lastmod>2025-01-27</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>

--- a/public/terms-of-service/index.html
+++ b/public/terms-of-service/index.html
@@ -28,7 +28,7 @@
             <h2 class="mb-2 mt-6 text-2xl font-semibold">Privacy</h2>
             <p class="mb-4">
                 Our
-                <a href="/privacy-policy/" class="text-blue-600 underline"
+                <a href="/privacy-policy/index.html" class="text-blue-600 underline"
                     >Privacy Policy</a
                 >
                 describes how we collect, use, and share your information. By


### PR DESCRIPTION
## Summary
- point footer links to policy `index.html` pages
- include `index.html` in sitemap and robots directives
- link Terms of Service page to the updated Privacy Policy path

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aaf90e8a8483298b2d30aef2e42a69