### PR TITLE
Fix global stylesheet path in static policy pages

### DIFF
--- a/public/cookie-policy/index.html
+++ b/public/cookie-policy/index.html
@@ -13,7 +13,7 @@
             gtag('config', 'G-RGSJT8T1EF');
         </script>
         <title>Cookie Policy - Route 66 Hemp</title>
-        <link href="/app/globals.css" rel="stylesheet">
+        <link href="../../app/globals.css" rel="stylesheet">
     </head>
     <body class="bg-white text-gray-800 dark:bg-gray-900 dark:text-white">
         <main class="mx-auto max-w-4xl p-4">

--- a/public/privacy-policy/index.html
+++ b/public/privacy-policy/index.html
@@ -13,7 +13,7 @@
             gtag('config', 'G-RGSJT8T1EF');
         </script>
         <title>Privacy Policy - Route 66 Hemp</title>
-        <link href="/app/globals.css" rel="stylesheet" />
+        <link href="../../app/globals.css" rel="stylesheet" />
     </head>
     <body class="bg-white text-gray-800 dark:bg-gray-900 dark:text-white">
         <main class="mx-auto max-w-4xl p-4">

--- a/public/terms-of-service/index.html
+++ b/public/terms-of-service/index.html
@@ -13,7 +13,7 @@
             gtag('config', 'G-RGSJT8T1EF');
         </script>
         <title>Terms of Service - Route 66 Hemp</title>
-        <link href="app/globals.css" rel="stylesheet" />
+        <link href="../../app/globals.css" rel="stylesheet" />
     </head>
     <body class="auto-contrast bg-white text-gray-800 dark:bg-gray-900 dark:text-white">
         <main class="mx-auto max-w-4xl p-4">


### PR DESCRIPTION
## Summary
- use relative path to load app/globals.css in cookie policy, privacy policy, and terms-of-service pages

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab037b1b1c832995f16fed68d90589