### PR TITLE
Improve contrast for policy pages

### DIFF
--- a/app/cookie-policy/page.tsx
+++ b/app/cookie-policy/page.tsx
@@ -125,7 +125,7 @@ export default function CookiePolicyPage() {
         gtag('config', 'G-RGSJT8T1EF');
       `}</Script>
       <main
-        className="mx-auto max-w-4xl p-4"
+        className="policy-content mx-auto max-w-4xl p-4"
         dangerouslySetInnerHTML={{ __html: content }}
       />
     </>

--- a/app/globals.css
+++ b/app/globals.css
@@ -253,3 +253,13 @@ button {
 .add-to-cart {
   font-weight: bold;
 }
+
+/* Ensure readable text on legal policy pages */
+.policy-content {
+  color: var(--color-text-primary);
+}
+
+.policy-content a {
+  color: var(--color-secondary);
+  text-decoration: underline;
+}

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -17,7 +17,7 @@ export default function PrivacyPolicyPage() {
           gtag('config', 'G-RGSJT8T1EF');
         `}
       </Script>
-      <main className="mx-auto max-w-4xl p-4">
+      <main className="policy-content mx-auto max-w-4xl p-4">
         <h1 className="auto-contrast mb-4 text-3xl font-bold">
           Route 66 Hemp Privacy Policy
         </h1>

--- a/app/terms-of-service/page.tsx
+++ b/app/terms-of-service/page.tsx
@@ -15,7 +15,7 @@ export default function TermsOfServicePage() {
         gtag('js', new Date());
         gtag('config', 'G-RGSJT8T1EF');
       `}</Script>
-      <main className="mx-auto max-w-4xl p-4">
+      <main className="policy-content mx-auto max-w-4xl p-4">
         <h1 className="auto-contrast mb-4 text-3xl font-bold">
           Route 66 Hemp Terms of Service
         </h1>


### PR DESCRIPTION
## Summary
- add `.policy-content` styles to ensure readable text for legal policy pages
- apply `policy-content` class to privacy policy, terms of service, and cookie policy pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab0e2a5d5c83298b43285958aa38cf