### PR TITLE
Hide cart features and render products server-side

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -250,10 +250,6 @@ button {
   font-weight: bold;
 }
 
-.add-to-cart {
-  font-weight: bold;
-}
-
 /* Ensure readable text on legal policy pages */
 .policy-content {
   color: var(--color-text-primary);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,23 +1,29 @@
 import { Suspense } from 'react'
 import StructuredData from '@/components/StructuredData'
-import { CartProvider } from '@/hooks/useCart'
-import ClientHomePage from '@/components/ClientHomePage'
+import HomePageContent from '@/components/HomePage'
+import fs from 'fs/promises'
+import path from 'path'
 
+export default async function HomePage() {
+    const file = await fs.readFile(
+        path.join(process.cwd(), 'public', 'products', 'products.json'),
+        'utf-8'
+    )
+    const products = JSON.parse(file)
 
-export default function HomePage() {
     return (
-        <CartProvider>
-            <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-                <StructuredData />
-                <Suspense fallback={
+        <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+            <StructuredData />
+            <Suspense
+                fallback={
                     <div className="flex min-h-screen items-center justify-center">
                         <div className="leaf-loader animate-spin"></div>
                         <span className="ml-3 text-lg">Loading...</span>
                     </div>
-                }>
-                    <ClientHomePage />
-                </Suspense>
-            </div>
-        </CartProvider>
+                }
+            >
+                <HomePageContent products={products} />
+            </Suspense>
+        </div>
     )
 }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,4 +1,3 @@
-import { CartProvider } from '@/hooks/useCart';
 export function Providers({ children }: { children: React.ReactNode }) {
-  return <CartProvider>{children}</CartProvider>;
+  return <>{children}</>;
 }

--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -1,16 +1,13 @@
-'use client';
-import { useEffect, useState } from 'react'
+'use client'
+import { useEffect } from 'react'
 import Navigation from '@/components/Navigation'
 import FooterNavigation from '@/components/FooterNavigation'
 import QuickNavigation from '@/components/QuickNavigation'
 import LocalSEOFAQ from '@/components/LocalSEOFAQ'
 import LocationContent from '@/components/LocationContent'
 import GoogleBusinessIntegration from '@/components/GoogleBusinessIntegration'
-import CartDrawer from '@/components/CartDrawer'
-import CartPage from '@/components/CartPage'
 import { useKeyboardNavigation } from '@/hooks/useNavigation'
 import { applyAutoContrast } from '@/utils/autoContrast'
-import { initCartButtonListener } from '@/utils/cartEvents'
 import { slugify } from '@/utils/slugify'
 import HeroSection from '@/components/HeroSection'
 import AboutSection from '@/components/AboutSection'
@@ -27,27 +24,8 @@ interface Product {
     availability?: Record<string, boolean>
 }
 
-export default function ClientHomePage() {
-    const [products, setProducts] = useState<Product[]>([])
-    const [loading, setLoading] = useState(true)
-    const [error, setError] = useState<string | null>(null)
-
+export default function HomePage({ products }: { products: Product[] }) {
     useKeyboardNavigation()
-
-    useEffect(() => {
-        fetch('/products/products.json')
-            .then(res => res.json())
-            .then((data: Product[]) => setProducts(data))
-            .catch((err: Error) => {
-                setError('Failed to load products')
-                console.error(err)
-            })
-            .finally(() => setLoading(false))
-    }, [])
-
-    useEffect(() => {
-        initCartButtonListener()
-    }, [])
 
     useEffect(() => {
         applyAutoContrast()
@@ -67,32 +45,6 @@ export default function ClientHomePage() {
             return rank(a) - rank(b) || a.name.localeCompare(b.name)
         })
     })
-
-    if (loading) {
-        return (
-            <div className="flex min-h-screen items-center justify-center">
-                <div className="leaf-loader animate-spin"></div>
-                <span className="ml-3 text-lg">Loading products...</span>
-            </div>
-        )
-    }
-
-    if (error) {
-        return (
-            <div className="flex min-h-screen items-center justify-center text-center">
-                <div>
-                    <h1 className="text-2xl font-bold text-red-600">Error</h1>
-                    <p className="mt-2 text-gray-700">{error}</p>
-                    <button
-                        onClick={() => location.reload()}
-                        className="mt-4 rounded bg-green-600 px-4 py-2 text-white"
-                    >
-                        Try Again
-                    </button>
-                </div>
-            </div>
-        )
-    }
 
     return (
         <>
@@ -122,8 +74,6 @@ export default function ClientHomePage() {
             </main>
             <FooterNavigation />
             <QuickNavigation />
-            <CartDrawer />
-            <CartPage />
         </>
     )
 }

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -3,7 +3,6 @@ import React, { useState, useEffect } from 'react'
 import LocalBusinessInfo from './LocalBusinessInfo'
 import SearchNavigation from './SearchNavigation'
 import { slugify } from '../utils/slugify'
-import { useCart } from '../hooks/useCart'
 
 
 interface Product {
@@ -28,8 +27,6 @@ function Navigation({ products = [] }: { products: Product[] }) {
     const [activeSection, setActiveSection] = useState('home')
     const [activeDropdown, setActiveDropdown] = useState<string | null>(null)
     const [dropdownTimeout, setDropdownTimeout] = useState<ReturnType<typeof setTimeout> | null>(null)
-    const { cart, openCart } = useCart()
-    const totalItems = cart.items.reduce((sum, item) => sum + item.qty, 0)
 
     // Handle scroll effects
     useEffect(() => {
@@ -338,32 +335,6 @@ function Navigation({ products = [] }: { products: Product[] }) {
                                     (573) 677-6418
                                 </a>
                             </div>
-
-                            {/* Cart Button */}
-                            <button
-                                onClick={openCart}
-                                aria-label={`Open cart${
-                                    totalItems > 0
-                                        ? ` (${totalItems} item${totalItems === 1 ? '' : 's'})`
-                                        : ''
-                                }`}
-                                className="relative rounded p-2 text-gray-700 hover:text-green-600 dark:text-gray-300 dark:hover:text-green-400"
-                            >
-                                <i
-                                    className="fas fa-shopping-cart"
-                                    aria-hidden="true"
-                                />
-                                <span
-                                    aria-live="polite"
-                                    className={
-                                        totalItems > 0
-                                            ? 'absolute -right-1 -top-1 rounded-full bg-red-600 px-1 text-xs text-white'
-                                            : 'sr-only'
-                                    }
-                                >
-                                    {totalItems}
-                                </span>
-                            </button>
 
                             {/* Mobile menu button */}
                             <button

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useState, useEffect } from 'react'
+import Image from 'next/image'
 import { slugify } from '@/utils/slugify'
 
 interface Product {
@@ -41,6 +42,13 @@ export default function ProductCard({ product }: { product: Product }) {
                     {product.banner}
                 </div>
             )}
+            <Image
+                src="/assets/images/placeholder.webp"
+                alt={product.name}
+                width={400}
+                height={300}
+                className="mb-4 h-48 w-full rounded object-cover"
+            />
             <div className="mb-4">
                 <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{product.name}</h3>
                 <p className="text-sm text-gray-600 dark:text-gray-300">{product.category || 'N/A'}</p>
@@ -68,22 +76,8 @@ export default function ProductCard({ product }: { product: Product }) {
                     <span className="text-sm font-medium text-gray-600 dark:text-gray-300">{selectedSize || 'N/A'}</span>
                 )}
             </div>
-            <div className="flex items-center justify-between">
+            <div className="flex items-center justify-center">
                 <div className="text-xl font-bold text-green-600">${currentPrice?.toFixed(2) || 'N/A'}</div>
-                <button
-                    className={`add-to-cart rounded-md px-4 py-2 ${isOutOfStock ? 'cursor-not-allowed bg-white text-black hover:text-red-600' : 'bg-emerald-700 text-white hover:bg-white hover:text-green-600 focus:outline-green-500 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 active:bg-emerald-600 active:text-white'}`}
-                    disabled={isOutOfStock}
-                    aria-label={isOutOfStock ? `Out of Stock ${product.name}` : `Add to Cart ${product.name}`}
-                    data-product-id={slugify(product.name)}
-                    data-variant-id={`${slugify(product.name)}_${slugify(selectedSize)}`}
-                    data-name={product.name}
-                    data-price={currentPrice?.toFixed(2) || 0}
-                    data-currency="USD"
-                    data-image=""
-                    data-available={!isOutOfStock}
-                >
-                    <span className="text-lg font-bold">{isOutOfStock ? 'Out of Stock' : 'Add to Cart'}</span>
-                </button>
             </div>
         </div>
     )


### PR DESCRIPTION
## Summary
- Drop cart-related components and UI hooks
- Render product catalog on the server and pass data to client
- Use Next.js `Image` for optimized product placeholders

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5d85895cc8329a083583ded3a9f4c