### PR TITLE
Improve footer link grid responsiveness

### DIFF
--- a/components/FooterNavigation.tsx
+++ b/components/FooterNavigation.tsx
@@ -144,25 +144,27 @@ function FooterNavigation() {
                     </div>
 
                     {/* Footer Links */}
-                    {footerSections.map((section) => (
-                        <div key={section.title}>
-                            <h4 className="mb-4 text-lg font-semibold">
-                                {section.title}
-                            </h4>
-                            <ul className="space-y-2">
-                                {section.links.map((link) => (
-                                    <li key={link.label}>
-                                        <a
-                                            href={link.href}
-                                            className="text-sm text-gray-300 transition-colors hover:text-green-400"
-                                        >
-                                            {link.label}
-                                        </a>
-                                    </li>
-                                ))}
-                            </ul>
-                        </div>
-                    ))}
+                    <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:col-span-4 lg:grid-cols-4">
+                        {footerSections.map((section) => (
+                            <div key={section.title}>
+                                <h4 className="mb-4 text-lg font-semibold">
+                                    {section.title}
+                                </h4>
+                                <ul className="space-y-2">
+                                    {section.links.map((link) => (
+                                        <li key={link.label}>
+                                            <a
+                                                href={link.href}
+                                                className="text-sm text-gray-300 transition-colors hover:text-green-400"
+                                            >
+                                                {link.label}
+                                            </a>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        ))}
+                    </div>
                 </div>
 
                 {/* Bottom Footer */}


### PR DESCRIPTION
## Summary
- reorganize the footer navigation links into a nested grid that steps from four columns down to one as the viewport shrinks
- keep the business info block spanning multiple columns on large screens while retaining existing content

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca17b93c608329a945134882b1189a