### PR TITLE
Improve footer grid responsiveness

### DIFF
--- a/components/FooterNavigation.tsx
+++ b/components/FooterNavigation.tsx
@@ -86,9 +86,9 @@ function FooterNavigation() {
         <footer className="auto-contrast bg-gray-900 text-white border-t border-gray-800">
             <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
                 {/* Main Footer Content */}
-                <div className="grid grid-cols-1 gap-8 lg:grid-cols-6">
+                <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6">
                     {/* Business Info */}
-                    <div className="lg:col-span-2">
+                    <div className="sm:col-span-2 md:col-span-3 lg:col-span-2">
                         <div className="mb-6">
                             <div className="mb-4 flex items-center space-x-3">
                                 <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-600">

--- a/components/FooterNavigation.tsx
+++ b/components/FooterNavigation.tsx
@@ -145,7 +145,10 @@ function FooterNavigation() {
 
                     {/* Footer Links */}
                     {footerSections.map((section) => (
-                        <div key={section.title}>
+                        <div
+                            key={section.title}
+                            className="flex flex-col items-center text-center md:items-start md:text-left"
+                        >
                             <h4 className="mb-4 text-lg font-semibold">
                                 {section.title}
                             </h4>


### PR DESCRIPTION
## Summary
- update the footer grid to introduce sm and md breakpoints so the link sections step down as the viewport narrows
- keep the business info block spanning multiple columns on large screens while letting it take the full width on smaller breakpoints

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca17b93c608329a945134882b1189a