### PR TITLE
Add aria-labelledby association for FAQ answers

### DIFF
--- a/components/LocalSEOFAQ.tsx
+++ b/components/LocalSEOFAQ.tsx
@@ -86,7 +86,10 @@ function LocalSEOFAQ() {
                                 aria-expanded={openIndex === index}
                                 aria-controls={`faq-answer-${index}`}
                             >
-                                <span className="pr-4 font-medium dark:text-white">
+                                <span
+                                    id={`faq-question-${index}`}
+                                    className="pr-4 font-medium dark:text-white"
+                                >
                                     {faq.question}
                                 </span>
                                 <i


### PR DESCRIPTION
## Summary
- add ids to FAQ question labels so answers can reference them via aria-labelledby

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca2ebf498083299fca3164c4ef7350