### PR TITLE
Add CSP script hashes for structured data

### DIFF
--- a/components/StructuredData.tsx
+++ b/components/StructuredData.tsx
@@ -1,4 +1,9 @@
-'use client'
+import {
+    breadcrumbStructuredData,
+    businessStructuredData,
+    organizationStructuredData,
+} from '@/data/structuredData'
+
 // Structured Data Component for Local Business SEO
 
 /**
@@ -7,169 +12,24 @@
  * @returns {JSX.Element} The StructuredData component.
  */
 function StructuredData() {
-    const businessData = {
-        '@context': 'https://schema.org',
-        '@type': 'Store',
-        name: 'Route 66 Hemp',
-        description:
-            'Premium hemp products for your wellness journey. Quality you can trust.',
-        url: 'https://www.route66hemp.com',
-        telephone: '+1-573-677-6418',
-        email: 'route66hemp@gmail.com',
-        address: {
-            '@type': 'PostalAddress',
-            streetAddress: '14076 State Hwy Z',
-            addressLocality: 'St Robert',
-            addressRegion: 'MO',
-            postalCode: '65584',
-            addressCountry: 'US',
-        },
-        geo: {
-            '@type': 'GeoCoordinates',
-            latitude: '37.83490',
-            longitude: '-92.09725',
-        },
-        openingHoursSpecification: [
-            {
-                '@type': 'OpeningHoursSpecification',
-                dayOfWeek: ['Monday', 'Tuesday', 'Wednesday', 'Thursday'],
-                opens: '11:00',
-                closes: '21:00',
-            },
-            {
-                '@type': 'OpeningHoursSpecification',
-                dayOfWeek: ['Friday', 'Saturday'],
-                opens: '11:00',
-                closes: '22:00',
-            },
-            {
-                '@type': 'OpeningHoursSpecification',
-                dayOfWeek: 'Sunday',
-                opens: '11:00',
-                closes: '19:00',
-            },
-        ],
-        priceRange: '$',
-        currenciesAccepted: 'USD',
-        paymentAccepted: 'Cash, Credit Card',
-        image: 'https://www.route66hemp.com/og-image.jpg',
-        logo: 'https://www.route66hemp.com/favicon-32x32.png',
-        sameAs: [
-            'https://www.facebook.com/route66hemp',
-            'https://www.instagram.com/route66hemp',
-            'https://www.twitter.com/route66hemp',
-        ],
-        aggregateRating: {
-            '@type': 'AggregateRating',
-            ratingValue: '4.4',
-            reviewCount: '8',
-        },
-        review: [
-            {
-                '@type': 'Review',
-                author: {
-                    '@type': 'Person',
-                    name: 'Sarah Johnson',
-                },
-                reviewRating: {
-                    '@type': 'Rating',
-                    ratingValue: '5',
-                },
-                reviewBody:
-                    'Excellent quality hemp products and knowledgeable staff. Great selection and fair prices.',
-            },
-        ],
-        hasOfferCatalog: {
-            '@type': 'OfferCatalog',
-            name: 'Hemp Products',
-            itemListElement: [
-                {
-                    '@type': 'Offer',
-                    itemOffered: {
-                        '@type': 'Product',
-                        name: 'CBD Flower',
-                        category: 'Hemp Products',
-                    },
-                },
-                {
-                    '@type': 'Offer',
-                    itemOffered: {
-                        '@type': 'Product',
-                        name: 'Hemp Concentrates',
-                        category: 'Hemp Products',
-                    },
-                },
-                {
-                    '@type': 'Offer',
-                    itemOffered: {
-                        '@type': 'Product',
-                        name: 'Vapes & Cartridges',
-                        category: 'Hemp Products',
-                    },
-                },
-            ],
-        },
-    }
-
-    const breadcrumbData = {
-        '@context': 'https://schema.org',
-        '@type': 'BreadcrumbList',
-        itemListElement: [
-            {
-                '@type': 'ListItem',
-                position: 1,
-                name: 'Home',
-                item: 'https://www.route66hemp.com',
-            },
-            {
-                '@type': 'ListItem',
-                position: 2,
-                name: 'Products',
-                item: 'https://www.route66hemp.com',
-            },
-        ],
-    }
-
-    const organizationData = {
-        '@context': 'https://schema.org',
-        '@type': 'Organization',
-        name: 'Route 66 Hemp',
-        url: 'https://www.route66hemp.com',
-        logo: 'https://www.route66hemp.com/favicon-32x32.png',
-        contactPoint: {
-            '@type': 'ContactPoint',
-            telephone: '+1-573-677-6418',
-            contactType: 'customer service',
-            availableLanguage: 'English',
-        },
-        address: {
-            '@type': 'PostalAddress',
-            streetAddress: '14076 State Hwy Z',
-            addressLocality: 'St Robert',
-            addressRegion: 'MO',
-            postalCode: '65584',
-            addressCountry: 'US',
-        },
-    }
-
     return (
         <>
             <script
                 type="application/ld+json"
                 dangerouslySetInnerHTML={{
-                    __html: JSON.stringify(businessData),
+                    __html: JSON.stringify(businessStructuredData),
                 }}
             />
             <script
                 type="application/ld+json"
                 dangerouslySetInnerHTML={{
-                    __html: JSON.stringify(breadcrumbData),
+                    __html: JSON.stringify(breadcrumbStructuredData),
                 }}
             />
             <script
                 type="application/ld+json"
                 dangerouslySetInnerHTML={{
-                    __html: JSON.stringify(organizationData),
+                    __html: JSON.stringify(organizationStructuredData),
                 }}
             />
         </>

--- a/data/structuredData.ts
+++ b/data/structuredData.ts
@@ -1,0 +1,150 @@
+export const businessStructuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'Store',
+    name: 'Route 66 Hemp',
+    description:
+        'Premium hemp products for your wellness journey. Quality you can trust.',
+    url: 'https://www.route66hemp.com',
+    telephone: '+1-573-677-6418',
+    email: 'route66hemp@gmail.com',
+    address: {
+        '@type': 'PostalAddress',
+        streetAddress: '14076 State Hwy Z',
+        addressLocality: 'St Robert',
+        addressRegion: 'MO',
+        postalCode: '65584',
+        addressCountry: 'US',
+    },
+    geo: {
+        '@type': 'GeoCoordinates',
+        latitude: '37.83490',
+        longitude: '-92.09725',
+    },
+    openingHoursSpecification: [
+        {
+            '@type': 'OpeningHoursSpecification',
+            dayOfWeek: ['Monday', 'Tuesday', 'Wednesday', 'Thursday'],
+            opens: '11:00',
+            closes: '21:00',
+        },
+        {
+            '@type': 'OpeningHoursSpecification',
+            dayOfWeek: ['Friday', 'Saturday'],
+            opens: '11:00',
+            closes: '22:00',
+        },
+        {
+            '@type': 'OpeningHoursSpecification',
+            dayOfWeek: 'Sunday',
+            opens: '11:00',
+            closes: '19:00',
+        },
+    ],
+    priceRange: '$',
+    currenciesAccepted: 'USD',
+    paymentAccepted: 'Cash, Credit Card',
+    image: 'https://www.route66hemp.com/og-image.jpg',
+    logo: 'https://www.route66hemp.com/favicon-32x32.png',
+    sameAs: [
+        'https://www.facebook.com/route66hemp',
+        'https://www.instagram.com/route66hemp',
+        'https://www.twitter.com/route66hemp',
+    ],
+    aggregateRating: {
+        '@type': 'AggregateRating',
+        ratingValue: '4.4',
+        reviewCount: '8',
+    },
+    review: [
+        {
+            '@type': 'Review',
+            author: {
+                '@type': 'Person',
+                name: 'Sarah Johnson',
+            },
+            reviewRating: {
+                '@type': 'Rating',
+                ratingValue: '5',
+            },
+            reviewBody:
+                'Excellent quality hemp products and knowledgeable staff. Great selection and fair prices.',
+        },
+    ],
+    hasOfferCatalog: {
+        '@type': 'OfferCatalog',
+        name: 'Hemp Products',
+        itemListElement: [
+            {
+                '@type': 'Offer',
+                itemOffered: {
+                    '@type': 'Product',
+                    name: 'CBD Flower',
+                    category: 'Hemp Products',
+                },
+            },
+            {
+                '@type': 'Offer',
+                itemOffered: {
+                    '@type': 'Product',
+                    name: 'Hemp Concentrates',
+                    category: 'Hemp Products',
+                },
+            },
+            {
+                '@type': 'Offer',
+                itemOffered: {
+                    '@type': 'Product',
+                    name: 'Vapes & Cartridges',
+                    category: 'Hemp Products',
+                },
+            },
+        ],
+    },
+} as const
+
+export const breadcrumbStructuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+        {
+            '@type': 'ListItem',
+            position: 1,
+            name: 'Home',
+            item: 'https://www.route66hemp.com',
+        },
+        {
+            '@type': 'ListItem',
+            position: 2,
+            name: 'Products',
+            item: 'https://www.route66hemp.com',
+        },
+    ],
+} as const
+
+export const organizationStructuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    name: 'Route 66 Hemp',
+    url: 'https://www.route66hemp.com',
+    logo: 'https://www.route66hemp.com/favicon-32x32.png',
+    contactPoint: {
+        '@type': 'ContactPoint',
+        telephone: '+1-573-677-6418',
+        contactType: 'customer service',
+        availableLanguage: 'English',
+    },
+    address: {
+        '@type': 'PostalAddress',
+        streetAddress: '14076 State Hwy Z',
+        addressLocality: 'St Robert',
+        addressRegion: 'MO',
+        postalCode: '65584',
+        addressCountry: 'US',
+    },
+} as const
+
+export const structuredDataDocuments = [
+    businessStructuredData,
+    breadcrumbStructuredData,
+    organizationStructuredData,
+] as const

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,21 @@
+import { createHash } from 'crypto'
 import type { NextConfig } from 'next'
+
+import { structuredDataDocuments } from './data/structuredData'
+
+const structuredDataScriptHashes = structuredDataDocuments.map((document) =>
+  createHash('sha256').update(JSON.stringify(document), 'utf8').digest('base64')
+)
+
+const scriptSrcDirective = [
+  "'self'",
+  'https://www.googletagmanager.com',
+  'https://www.google-analytics.com',
+  'https://analytics.google.com',
+  'https://va.vercel-scripts.com',
+  'https://vitals.vercel-insights.com',
+  ...structuredDataScriptHashes.map((hash) => `'sha256-${hash}'`),
+].join(' ')
 
 const securityHeaders = [
   {
@@ -6,8 +23,8 @@ const securityHeaders = [
     // CSP directives are concatenated into one string
     value: [
       "default-src 'self'",
-      // Allow only our own scripts and specific analytics providers; keep 'unsafe-inline' until nonces/hashes can be added
-      "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://analytics.google.com https://va.vercel-scripts.com https://vitals.vercel-insights.com",
+      // Allow our own scripts, trusted analytics providers, and the specific structured data inline scripts (via hashes)
+      `script-src ${scriptSrcDirective}`,
       // Allow connections to GA, GTM and Vercel for analytics and vitals
       "connect-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://analytics.google.com https://va.vercel-scripts.com https://vitals.vercel-insights.com",
       // Permit images from the same origin, data URIs and blobs (Next/Image uses blobs)


### PR DESCRIPTION
## Summary
- centralize JSON-LD definitions in a shared module for reuse and consistent hashing
- remove the CSP `unsafe-inline` allowance and whitelist the structured data inline scripts via SHA-256 hashes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cab05c21c4832985396ecced1929da