### PR TITLE
Implement CSP nonce handling for inline scripts

### DIFF
--- a/components/StructuredData.tsx
+++ b/components/StructuredData.tsx
@@ -4,10 +4,10 @@ import { headers } from 'next/headers'
 /**
  * StructuredData component for Local Business SEO.
  * Renders structured data for business information, breadcrumbs, and organization.
- * @returns {JSX.Element} The StructuredData component.
+ * @returns {Promise<JSX.Element>} The StructuredData component.
  */
-function StructuredData() {
-    const nonce = headers().get('x-csp-nonce') ?? undefined
+async function StructuredData() {
+    const nonce = (await headers()).get('x-csp-nonce') ?? undefined
 
     const businessData = {
         '@context': 'https://schema.org',

--- a/components/StructuredData.tsx
+++ b/components/StructuredData.tsx
@@ -1,4 +1,4 @@
-'use client'
+import { headers } from 'next/headers'
 // Structured Data Component for Local Business SEO
 
 /**
@@ -7,6 +7,8 @@
  * @returns {JSX.Element} The StructuredData component.
  */
 function StructuredData() {
+    const nonce = headers().get('x-csp-nonce') ?? undefined
+
     const businessData = {
         '@context': 'https://schema.org',
         '@type': 'Store',
@@ -155,18 +157,21 @@ function StructuredData() {
     return (
         <>
             <script
+                nonce={nonce}
                 type="application/ld+json"
                 dangerouslySetInnerHTML={{
                     __html: JSON.stringify(businessData),
                 }}
             />
             <script
+                nonce={nonce}
                 type="application/ld+json"
                 dangerouslySetInnerHTML={{
                     __html: JSON.stringify(breadcrumbData),
                 }}
             />
             <script
+                nonce={nonce}
                 type="application/ld+json"
                 dangerouslySetInnerHTML={{
                     __html: JSON.stringify(organizationData),

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+const ANALYTICS_SCRIPT_SOURCES = [
+  'https://www.googletagmanager.com',
+  'https://www.google-analytics.com',
+  'https://analytics.google.com',
+  'https://va.vercel-scripts.com',
+  'https://vitals.vercel-insights.com',
+]
+
+function generateNonce() {
+  const array = new Uint8Array(16)
+  crypto.getRandomValues(array)
+  let string = ''
+  array.forEach((value) => {
+    string += String.fromCharCode(value)
+  })
+
+  return btoa(string)
+}
+
+export function middleware(request: NextRequest) {
+  const nonce = generateNonce()
+
+  const csp = [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}' ${ANALYTICS_SCRIPT_SOURCES.join(' ')}`,
+    `connect-src 'self' ${ANALYTICS_SCRIPT_SOURCES.join(' ')}`,
+    "img-src 'self' data: blob:",
+    "style-src 'self' 'unsafe-inline'",
+    "font-src 'self' data:",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "frame-ancestors 'none'",
+  ].join('; ')
+
+  const requestHeaders = new Headers(request.headers)
+  requestHeaders.set('x-csp-nonce', nonce)
+
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  })
+
+  response.headers.set('Content-Security-Policy', csp)
+
+  return response
+}
+
+export const config = {
+  matcher: '/:path*',
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,31 +1,7 @@
 import type { NextConfig } from 'next'
 
+// The Content-Security-Policy is issued dynamically with a per-request nonce in middleware.ts.
 const securityHeaders = [
-  {
-    key: 'Content-Security-Policy',
-    // CSP directives are concatenated into one string
-    value: [
-      "default-src 'self'",
-      // Allow only our own scripts and specific analytics providers; keep 'unsafe-inline' until nonces/hashes can be added
-      "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://analytics.google.com https://va.vercel-scripts.com https://vitals.vercel-insights.com",
-      // Allow connections to GA, GTM and Vercel for analytics and vitals
-      "connect-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://analytics.google.com https://va.vercel-scripts.com https://vitals.vercel-insights.com",
-      // Permit images from the same origin, data URIs and blobs (Next/Image uses blobs)
-      "img-src 'self' data: blob:",
-      // Permit inline styles (Tailwind injects them) but nothing external; if you add external stylesheets, list their domains here
-      "style-src 'self' 'unsafe-inline'",
-      // Allow local fonts and data URIs
-      "font-src 'self' data:",
-      // Disallow all plugin content
-      "object-src 'none'",
-      // Disallow the use of <base> tags from setting an unexpected base URL
-      "base-uri 'self'",
-      // Prevent the site from being embedded in frames or iframes
-      "frame-ancestors 'none'",
-      // Uncomment to automatically upgrade all HTTP requests to HTTPS
-      // "upgrade-insecure-requests",
-    ].join('; '),
-  },
   // Click‑jacking protection: frame‑ancestors is sufficient; X‑Frame‑Options is redundant
   { key: 'X-Content-Type-Options', value: 'nosniff' },
   { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },


### PR DESCRIPTION
## Summary
- add middleware that issues a Content-Security-Policy with a per-request nonce and shares it with the request pipeline
- remove the static CSP header from next.config.ts now that it is provided dynamically
- apply the nonce to structured data JSON-LD scripts so they comply with the stricter policy

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cab05c21c4832985396ecced1929da