### PR TITLE
Make home page static to enable bfcache

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,29 +1,14 @@
-import { Suspense } from 'react'
 import StructuredData from '@/components/StructuredData'
 import HomePageContent from '@/components/HomePage'
-import fs from 'fs/promises'
-import path from 'path'
+import products from '@/public/products/products.json'
 
-export default async function HomePage() {
-    const file = await fs.readFile(
-        path.join(process.cwd(), 'public', 'products', 'products.json'),
-        'utf-8'
-    )
-    const products = JSON.parse(file)
+export const dynamic = 'force-static'
 
+export default function HomePage() {
     return (
         <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
             <StructuredData />
-            <Suspense
-                fallback={
-                    <div className="flex min-h-screen items-center justify-center">
-                        <div className="leaf-loader animate-spin"></div>
-                        <span className="ml-3 text-lg">Loading...</span>
-                    </div>
-                }
-            >
-                <HomePageContent products={products} />
-            </Suspense>
+            <HomePageContent products={products} />
         </div>
     )
 }


### PR DESCRIPTION
## Summary
- load the home page product catalog from a static JSON import instead of fs
- mark the home page as force-static so the main response can be cached and eligible for bfcache

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d70caa18348329b1e88903592bbcbb