### PR TITLE
Ensure home page is statically generated

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,8 @@ import HomePageContent from '@/components/HomePage'
 import fs from 'fs/promises'
 import path from 'path'
 
+export const dynamic = 'force-static'
+
 export default async function HomePage() {
     const file = await fs.readFile(
         path.join(process.cwd(), 'public', 'products', 'products.json'),


### PR DESCRIPTION
## Summary
- force static rendering of the home page so it can be cached and eligible for the back/forward cache

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d70caa18348329b1e88903592bbcbb