### PR TITLE
Adjust product list ARIA semantics

### DIFF
--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -51,10 +51,9 @@ export default function ProductCard({ product, priority = false, gridIndex, grid
     const showProductImage = false // Toggle when real product photography is available
 
     return (
-        <div
+        <article
             id={cardId}
             className={`product-card relative min-w-[285px] rounded-lg bg-white p-6 shadow-md transition-all duration-300 hover:shadow-lg sm:w-full md:w-1/2 lg:w-1/3 xl:w-1/4 dark:bg-gray-800 focus-enhanced ${isOutOfStock ? 'opacity-75' : ''}`}
-            role="article"
             tabIndex={0}
             data-product-card="true"
             data-grid-index={typeof gridIndex === 'number' ? gridIndex : undefined}
@@ -123,7 +122,7 @@ export default function ProductCard({ product, priority = false, gridIndex, grid
             <div className="flex items-center justify-center">
                 <div id={priceId} className="text-xl font-bold text-green-600">{priceLabel}</div>
             </div>
-        </div>
+        </article>
     )
 }
 

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -53,7 +53,7 @@ export default function ProductCard({ product, priority = false, gridIndex, grid
     return (
         <article
             id={cardId}
-            className={`product-card relative min-w-[285px] rounded-lg bg-white p-6 shadow-md transition-all duration-300 hover:shadow-lg sm:w-full md:w-1/2 lg:w-1/3 xl:w-1/4 dark:bg-gray-800 focus-enhanced ${isOutOfStock ? 'opacity-75' : ''}`}
+            className={`product-card relative min-w-[285px] w-full rounded-lg bg-white p-6 shadow-md transition-all duration-300 hover:shadow-lg dark:bg-gray-800 focus-enhanced ${isOutOfStock ? 'opacity-75' : ''}`}
             tabIndex={0}
             data-product-card="true"
             data-grid-index={typeof gridIndex === 'number' ? gridIndex : undefined}

--- a/components/ProductSection.tsx
+++ b/components/ProductSection.tsx
@@ -40,23 +40,24 @@ export default function ProductSection({ title, products, categoryId, isFirstSec
                 >
                     {title}
                 </h2>
-                <div
-                    className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
-                    role="grid"
+                <ul
+                    className="grid list-none grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+                    role="list"
                     aria-labelledby={headingId}
                     data-product-grid
                 >
                     {products.map((product, index) => (
-                        <ProductCard
-                            key={product.name}
-                            product={product}
-                            priority={isFirstSection && index === 0}
-                            gridIndex={index}
-                            gridSize={totalItems}
-                            parentHeadingId={headingId}
-                        />
+                        <li key={product.name} className="list-none">
+                            <ProductCard
+                                product={product}
+                                priority={isFirstSection && index === 0}
+                                gridIndex={index}
+                                gridSize={totalItems}
+                                parentHeadingId={headingId}
+                            />
+                        </li>
                     ))}
-                </div>
+                </ul>
             </div>
         </section>
     )


### PR DESCRIPTION
## Summary
- replace the product grid role with a semantic list wrapper to satisfy required child roles
- render product cards as articles instead of divs that mimic the article role

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d713245e048329a8e689a26e21d492