### PR TITLE
Fix CSP nonce propagation for inline scripts

### DIFF
--- a/components/StructuredData.tsx
+++ b/components/StructuredData.tsx
@@ -7,7 +7,7 @@ import { headers } from 'next/headers'
  * @returns {Promise<JSX.Element>} The StructuredData component.
  */
 async function StructuredData() {
-    const nonce = (await headers()).get('x-csp-nonce') ?? undefined
+    const nonce = (await headers()).get('x-nonce') ?? undefined
 
     const businessData = {
         '@context': 'https://schema.org',

--- a/middleware.ts
+++ b/middleware.ts
@@ -36,7 +36,7 @@ export function middleware(request: NextRequest) {
   ].join('; ')
 
   const requestHeaders = new Headers(request.headers)
-  requestHeaders.set('x-csp-nonce', nonce)
+  requestHeaders.set('x-nonce', nonce)
 
   const response = NextResponse.next({
     request: {


### PR DESCRIPTION
## Summary
- set the CSP nonce header that Next.js expects so its inline runtime scripts receive a nonce automatically
- update structured data component to read the updated nonce header for JSON-LD tags

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d718adf7a88329a64107ec074793b1