### PR TITLE
Ensure structured data scripts honor CSP nonce

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import fs from 'fs/promises'
 import path from 'path'
 
 
-export const dynamic = 'force-static'
+export const dynamic = 'force-dynamic'
 
 export default async function HomePage() {
     const file = await fs.readFile(

--- a/components/StructuredData.tsx
+++ b/components/StructuredData.tsx
@@ -15,10 +15,11 @@ function extractCspNonce(headerList: HeaderList): string | undefined {
         return undefined
     }
 
-    const directive = cspHeader
-        .split(';')
-        .map((entry) => entry.trim())
-        .find((entry) => entry.startsWith('script-src') || entry.startsWith('default-src'))
+    const directives = cspHeader.split(';').map((entry) => entry.trim())
+
+    const directive =
+        directives.find((entry) => entry.startsWith('script-src')) ??
+        directives.find((entry) => entry.startsWith('default-src'))
 
     if (!directive) {
         return undefined

--- a/components/StructuredData.tsx
+++ b/components/StructuredData.tsx
@@ -1,4 +1,37 @@
 import { headers } from 'next/headers'
+
+type HeaderList = Awaited<ReturnType<typeof headers>>
+
+function extractCspNonce(headerList: HeaderList): string | undefined {
+    const directNonce = headerList.get('x-csp-nonce')
+    if (directNonce) {
+        return directNonce
+    }
+
+    const cspHeader =
+        headerList.get('content-security-policy') ??
+        headerList.get('content-security-policy-report-only')
+    if (!cspHeader) {
+        return undefined
+    }
+
+    const directive = cspHeader
+        .split(';')
+        .map((entry) => entry.trim())
+        .find((entry) => entry.startsWith('script-src') || entry.startsWith('default-src'))
+
+    if (!directive) {
+        return undefined
+    }
+
+    const source = directive
+        .split(/\s+/)
+        .slice(1)
+        .find((value) => value.startsWith("'nonce-") && value.endsWith("'"))
+
+    return source ? source.slice(7, -1) : undefined
+}
+
 // Structured Data Component for Local Business SEO
 
 /**
@@ -7,7 +40,8 @@ import { headers } from 'next/headers'
  * @returns {Promise<JSX.Element>} The StructuredData component.
  */
 async function StructuredData() {
-    const nonce = (await headers()).get('x-csp-nonce') ?? undefined
+    const headerList = await headers()
+    const nonce = extractCspNonce(headerList)
 
     const businessData = {
         '@context': 'https://schema.org',


### PR DESCRIPTION
## Summary
- add a helper to read the CSP nonce from request headers and use it on structured data scripts
- force the home page to render dynamically so per-request nonces can be applied

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d718adf7a88329a64107ec074793b1