### PR TITLE
refactor: harden data loading and security

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,21 +2,12 @@
 import { Suspense } from 'react'
 import StructuredData from '@/components/StructuredData'
 import HomePageContent from '@/components/HomePage'
-import fs from 'fs/promises'
-import path from 'path'
+import { getProducts } from '@/lib/products.server'
 
-// Remove force-dynamic to allow proper caching
-// export const dynamic = 'force-dynamic' // REMOVE THIS LINE
-
-// Add proper cache configuration
 export const revalidate = 3600 // Revalidate every hour
 
 export default async function HomePage() {
-    const file = await fs.readFile(
-        path.join(process.cwd(), 'public', 'products', 'products.json'),
-        'utf-8'
-    )
-    const products = JSON.parse(file)
+    const products = await getProducts()
 
     return (
         <div className="min-h-screen bg-gray-50 dark:bg-gray-900">

--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import Navigation from '@/components/Navigation'
 import FooterNavigation from '@/components/FooterNavigation'
 import QuickNavigation from '@/components/QuickNavigation'
@@ -13,38 +13,17 @@ import HeroSection from '@/components/HeroSection'
 import AboutSection from '@/components/AboutSection'
 import ContactSection from '@/components/ContactSection'
 import ProductSection from '@/components/ProductSection'
-
-interface Product {
-    name: string
-    category: string
-    size_options: string[]
-    prices: Record<string, number>
-    thca_percentage?: number
-    banner?: string
-    availability?: Record<string, boolean>
-}
+import { groupProductsByCategory } from '@/lib/products'
+import type { Product } from '@/types/product'
 
 export default function HomePage({ products }: { products: Product[] }) {
     useKeyboardNavigation()
 
+    const productsByCategory = useMemo(() => groupProductsByCategory(products), [products])
+
     useEffect(() => {
         applyAutoContrast()
-    }, [products])
-
-    const productsByCategory = products.reduce((acc: Record<string, Product[]>, product: Product) => {
-        const cat = product.category || 'Uncategorized'
-        if (!acc[cat]) acc[cat] = []
-        acc[cat].push(product)
-        return acc
-    }, {})
-
-    Object.keys(productsByCategory).forEach(cat => {
-        productsByCategory[cat].sort((a: Product, b: Product) => {
-            const rank = (p: Product) =>
-                p.banner === 'New' ? 0 : p.banner === 'Out of Stock' ? 2 : 1
-            return rank(a) - rank(b) || a.name.localeCompare(b.name)
-        })
-    })
+    }, [productsByCategory])
 
     return (
         <>

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -1,20 +1,10 @@
-'use client';
+'use client'
 import React, { useState, useEffect } from 'react'
 import LocalBusinessInfo from './LocalBusinessInfo'
 import SearchNavigation from './SearchNavigation'
 import { slugify } from '../utils/slugify'
 import { scrollToSection } from '../utils/scrollToSection'
-
-
-interface Product {
-    name: string
-    category: string
-    size_options: string[]
-    prices: Record<string, number>
-    thca_percentage?: number
-    banner?: string
-    availability?: Record<string, boolean>
-}
+import type { Product } from '@/types/product'
 
 /**
  * Navigation component for the header of the website.

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -2,16 +2,7 @@
 import { useState, useEffect } from 'react'
 import Image from 'next/image'
 import { slugify } from '@/utils/slugify'
-
-interface Product {
-    name: string
-    category: string
-    size_options: string[]
-    prices: Record<string, number>
-    thca_percentage?: number
-    banner?: string
-    availability?: Record<string, boolean>
-}
+import type { Product } from '@/types/product'
 
 interface ProductCardProps {
     product: Product

--- a/components/ProductSection.tsx
+++ b/components/ProductSection.tsx
@@ -1,15 +1,5 @@
-
 import ProductCard from './ProductCard'
-
-interface Product {
-    name: string
-    category: string
-    size_options: string[]
-    prices: Record<string, number>
-    thca_percentage?: number
-    banner?: string
-    availability?: Record<string, boolean>
-}
+import type { Product } from '@/types/product'
 
 interface ProductSectionProps {
     title: string

--- a/components/SearchNavigation.tsx
+++ b/components/SearchNavigation.tsx
@@ -1,17 +1,8 @@
-'use client';
+'use client'
 import React, { useState, useEffect, useRef, useCallback } from 'react'
 import AccessibilityAnnouncer from './AccessibilityAnnouncer'
 import { slugify } from '../utils/slugify'
-
-interface Product {
-    name: string
-    category: string
-    size_options: string[]
-    prices: Record<string, number>
-    thca_percentage?: number
-    banner?: string
-    availability?: Record<string, boolean>
-}
+import type { Product } from '@/types/product'
 
 function SearchNavigation({ products = [] }: { products: Product[] }) {
     const [isOpen, setIsOpen] = useState(false)

--- a/lib/products.server.ts
+++ b/lib/products.server.ts
@@ -1,4 +1,3 @@
-import { cache } from 'react'
 import path from 'node:path'
 import { readFile } from 'node:fs/promises'
 import { Product } from '@/types/product'
@@ -119,5 +118,7 @@ async function loadProducts(): Promise<Product[]> {
   return data.map((entry, index) => parseProduct(entry, index))
 }
 
-export const getProducts = cache(async (): Promise<Product[]> => loadProducts())
+export async function getProducts(): Promise<Product[]> {
+  return loadProducts()
+}
 

--- a/lib/products.server.ts
+++ b/lib/products.server.ts
@@ -1,0 +1,123 @@
+import { cache } from 'react'
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
+import { Product } from '@/types/product'
+
+const PRODUCTS_PATH = path.join(process.cwd(), 'public', 'products', 'products.json')
+
+type JsonRecord = Record<string, unknown>
+
+type ValidationContext = {
+  index: number
+}
+
+function assert(condition: unknown, message: string, context?: ValidationContext): asserts condition {
+  if (!condition) {
+    const prefix = context ? `Product #${context.index}: ` : ''
+    throw new Error(prefix + message)
+  }
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return Boolean(value) && typeof value === 'object'
+}
+
+function normaliseString(value: unknown, field: string, ctx: ValidationContext): string {
+  assert(typeof value === 'string', `${field} must be a string`, ctx)
+  const trimmed = value.trim()
+  assert(trimmed.length > 0, `${field} cannot be empty`, ctx)
+  return trimmed
+}
+
+function normaliseStringArray(value: unknown, field: string, ctx: ValidationContext): string[] {
+  assert(Array.isArray(value), `${field} must be an array`, ctx)
+  assert(value.length > 0, `${field} cannot be empty`, ctx)
+  return value.map((entry, entryIndex) => {
+    const normalised = normaliseString(entry, `${field}[${entryIndex}]`, ctx)
+    return normalised
+  })
+}
+
+function normalisePrices(value: unknown, ctx: ValidationContext): Record<string, number> {
+  assert(isRecord(value), 'prices must be an object', ctx)
+  const entries = Object.entries(value)
+  assert(entries.length > 0, 'prices cannot be empty', ctx)
+
+  const result: Record<string, number> = {}
+  for (const [key, priceValue] of entries) {
+    const label = key.trim()
+    assert(label.length > 0, 'price labels cannot be empty', ctx)
+    assert(typeof priceValue === 'number' && Number.isFinite(priceValue), `price for "${key}" must be a finite number`, ctx)
+    assert(priceValue >= 0, `price for "${key}" cannot be negative`, ctx)
+    result[label] = priceValue
+  }
+
+  return result
+}
+
+function normaliseOptionalNumber(value: unknown, field: string, ctx: ValidationContext): number | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  assert(typeof value === 'number' && Number.isFinite(value), `${field} must be a finite number when present`, ctx)
+  assert(value >= 0, `${field} cannot be negative`, ctx)
+  return value
+}
+
+function normaliseAvailability(value: unknown, ctx: ValidationContext): Record<string, boolean> | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  assert(isRecord(value), 'availability must be an object when present', ctx)
+  const result: Record<string, boolean> = {}
+  for (const [key, availabilityValue] of Object.entries(value)) {
+    const label = key.trim()
+    assert(label.length > 0, 'availability keys cannot be empty', ctx)
+    assert(typeof availabilityValue === 'boolean', `availability for "${key}" must be boolean`, ctx)
+    result[label] = availabilityValue
+  }
+
+  return result
+}
+
+function parseProduct(value: unknown, index: number): Product {
+  const ctx: ValidationContext = { index }
+  assert(isRecord(value), 'each entry must be an object', ctx)
+
+  const name = normaliseString(value.name, 'name', ctx)
+  const category = normaliseString(value.category, 'category', ctx)
+  const sizeOptions = normaliseStringArray(value.size_options, 'size_options', ctx)
+  const prices = normalisePrices(value.prices, ctx)
+  const thca = normaliseOptionalNumber(value.thca_percentage, 'thca_percentage', ctx)
+  const banner = value.banner === undefined ? undefined : normaliseString(value.banner, 'banner', ctx)
+  const availability = normaliseAvailability(value.availability, ctx)
+
+  return {
+    name,
+    category,
+    size_options: sizeOptions,
+    prices,
+    thca_percentage: thca,
+    banner,
+    availability,
+  }
+}
+
+async function loadProducts(): Promise<Product[]> {
+  const raw = await readFile(PRODUCTS_PATH, 'utf8')
+  let data: unknown
+
+  try {
+    data = JSON.parse(raw)
+  } catch (error) {
+    throw new Error('Unable to parse products.json: ' + (error instanceof Error ? error.message : String(error)))
+  }
+
+  assert(Array.isArray(data), 'Products file must contain an array')
+  return data.map((entry, index) => parseProduct(entry, index))
+}
+
+export const getProducts = cache(async (): Promise<Product[]> => loadProducts())
+

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -1,0 +1,42 @@
+import type { Product, ProductMap } from '@/types/product'
+
+function sortProducts(products: Product[]): Product[] {
+  const priority = (product: Product): number => {
+    switch (product.banner) {
+      case 'New':
+        return 0
+      case 'Out of Stock':
+        return 2
+      default:
+        return 1
+    }
+  }
+
+  return [...products].sort((a, b) => {
+    const priorityDelta = priority(a) - priority(b)
+    if (priorityDelta !== 0) {
+      return priorityDelta
+    }
+
+    return a.name.localeCompare(b.name)
+  })
+}
+
+export function groupProductsByCategory(products: Product[]): ProductMap {
+  const map: ProductMap = {}
+  for (const product of products) {
+    const category = product.category || 'Uncategorized'
+    if (!map[category]) {
+      map[category] = []
+    }
+    map[category].push(product)
+  }
+
+  for (const [category, items] of Object.entries(map)) {
+    map[category] = sortProducts(items)
+  }
+
+  return map
+}
+
+export { sortProducts }

--- a/middleware.ts
+++ b/middleware.ts
@@ -40,21 +40,37 @@ export function middleware(request: NextRequest): NextResponse {
     },
   })
 
-  response.headers.set(
-    'Content-Security-Policy',
-    Object.entries({
-      "default-src": ["'self'"],
-      "script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
-      "connect-src": ["'self'", "'unsafe-inline'"], 
-      "style-src": ["'self'", "'unsafe-inline'"],
-      "font-src": ["'self'", "data:"],
-      "object-src": ["'none'"],
-      "base-uri": ["'self'"],
-      "frame-ancestors": ["'none'"],
-    })
-      .map(([key, values]) => `${key} ${values.join(' ')}`)
-      .join('; ')
-  )
+  const analyticsHosts = [
+    'https://www.googletagmanager.com',
+    'https://www.google-analytics.com',
+    'https://vitals.vercel-analytics.com',
+    'https://vitals.vercel-insights.com',
+    'https://www.gstatic.com',
+  ]
+
+  const cspDirectives: Record<string, string[]> = {
+    "default-src": ["'self'"],
+    "script-src": [
+      "'self'",
+      `'nonce-${nonceString}'`,
+      "'strict-dynamic'",
+      'https://www.googletagmanager.com',
+      'https://www.gstatic.com',
+    ],
+    "connect-src": ["'self'", ...analyticsHosts],
+    "style-src": ["'self'", "'unsafe-inline'"],
+    "img-src": ["'self'", 'data:', 'blob:'],
+    "font-src": ["'self'", 'data:'],
+    "object-src": ["'none'"],
+    "base-uri": ["'self'"],
+    "frame-ancestors": ["'none'"],
+  }
+
+  const csp = Object.entries(cspDirectives)
+    .map(([key, values]) => `${key} ${values.join(' ')}`)
+    .join('; ')
+
+  response.headers.set('Content-Security-Policy', csp)
 
   return response
 }

--- a/public/analytics-consent.js
+++ b/public/analytics-consent.js
@@ -46,6 +46,16 @@
     document.cookie = cookie
   }
 
+  function setSessionItem(key, value) {
+    try {
+      if (typeof window !== 'undefined' && window.sessionStorage) {
+        window.sessionStorage.setItem(key, value)
+      }
+    } catch {
+      // ignore storage failures
+    }
+  }
+
   function hasConfirmedAge() {
     return readCookie(AGE_COOKIE) === 'true'
   }
@@ -83,6 +93,10 @@
     const script = document.createElement('script')
     script.async = true
     script.src = 'https://www.googletagmanager.com/gtag/js?id=' + encodeURIComponent(GA_ID)
+    const nonce = typeof window !== 'undefined' ? window.__next_script_nonce__ : undefined
+    if (nonce) {
+      script.setAttribute('nonce', String(nonce))
+    }
     document.head.appendChild(script)
 
     window.gtag('js', new Date())
@@ -97,11 +111,7 @@
 
   function storeConsent(status) {
     writeCookie(CONSENT_COOKIE, status)
-    try {
-      localStorage.setItem('cookieConsent', status === 'accepted' ? 'accepted' : 'declined')
-    } catch {
-      // ignore storage failures
-    }
+    setSessionItem('cookieConsent', status === 'accepted' ? 'accepted' : 'declined')
     if (status === 'accepted') {
       tryInitAnalytics()
     } else {
@@ -111,11 +121,7 @@
 
   function confirmAge21() {
     writeCookie(AGE_COOKIE, 'true')
-    try {
-      localStorage.setItem('isAdult', 'true')
-    } catch {
-      // ignore storage failures
-    }
+    setSessionItem('isAdult', 'true')
     try {
       const evt = new CustomEvent('age:confirmed')
       window.dispatchEvent(evt)

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -4,6 +4,7 @@ declare global {
   interface Window {
     confirmAge21?: () => void
     tryInitAnalytics?: () => void
+    __next_script_nonce__?: string
   }
 }
 

--- a/types/product.ts
+++ b/types/product.ts
@@ -1,0 +1,11 @@
+export interface Product {
+  name: string
+  category: string
+  size_options: string[]
+  prices: Record<string, number>
+  thca_percentage?: number
+  banner?: string
+  availability?: Record<string, boolean>
+}
+
+export type ProductMap = Record<string, Product[]>


### PR DESCRIPTION
## Summary
- centralize product data loading with validation and shared product typing
- memoize homepage product grouping to reuse the shared catalog helper
- tighten the content security policy and align analytics consent script with nonce-aware loading

## Testing
- npm run lint
- npm test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d77a68c99883298ef0e94ef2e12bee