### PR TITLE
Add dedicated product catalog pages

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,13 +2,10 @@
 import { Suspense } from 'react'
 import StructuredData from '@/components/StructuredData'
 import HomePageContent from '@/components/HomePage'
-import { getProducts } from '@/lib/products.server'
 
 export const revalidate = 3600 // Revalidate every hour
 
-export default async function HomePage() {
-    const products = await getProducts()
-
+export default function HomePage() {
     return (
         <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
             <StructuredData />
@@ -20,7 +17,7 @@ export default async function HomePage() {
                     </div>
                 }
             >
-                <HomePageContent products={products} />
+                <HomePageContent />
             </Suspense>
         </div>
     )

--- a/app/products/[category]/page.tsx
+++ b/app/products/[category]/page.tsx
@@ -1,0 +1,63 @@
+import { notFound } from 'next/navigation'
+import Navigation from '@/components/Navigation'
+import FooterNavigation from '@/components/FooterNavigation'
+import QuickNavigation from '@/components/QuickNavigation'
+import HeroSection from '@/components/HeroSection'
+import LocationContent from '@/components/LocationContent'
+import ContactSection from '@/components/ContactSection'
+import GoogleBusinessIntegration from '@/components/GoogleBusinessIntegration'
+import LocalSEOFAQ from '@/components/LocalSEOFAQ'
+import ProductSection from '@/components/ProductSection'
+import { getProductCategories, getProductsByCategory } from '@/lib/products.server'
+
+export const revalidate = 3600
+
+type CategoryPageParams = {
+    params: {
+        category: string
+    }
+}
+
+export async function generateStaticParams() {
+    const categories = await getProductCategories()
+    return categories.map((category) => ({ category: category.slug }))
+}
+
+export default async function ProductCategoryPage({ params }: CategoryPageParams) {
+    const categoryData = await getProductsByCategory(params.category)
+
+    if (!categoryData) {
+        notFound()
+    }
+
+    const { categoryName, products } = categoryData
+
+    return (
+        <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+            <Navigation />
+            <main id="main-content" role="main" tabIndex={-1} className="outline-none">
+                <HeroSection />
+                <section className="py-12">
+                    <div className="container mx-auto px-4 text-center">
+                        <h1 className="mb-4 text-4xl font-bold text-gray-900 dark:text-white">{categoryName}</h1>
+                        <p className="mx-auto max-w-3xl text-lg text-gray-600 dark:text-gray-300">
+                            Explore our latest {categoryName.toLowerCase()} inventory, complete with pricing, available sizes, and product highlights.
+                        </p>
+                    </div>
+                </section>
+                <ProductSection
+                    title={categoryName}
+                    products={products}
+                    categoryId={params.category}
+                    isFirstSection
+                />
+                <LocationContent />
+                <ContactSection />
+                <GoogleBusinessIntegration />
+                <LocalSEOFAQ />
+            </main>
+            <FooterNavigation />
+            <QuickNavigation />
+        </div>
+    )
+}

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -1,0 +1,83 @@
+import Link from 'next/link'
+import Navigation from '@/components/Navigation'
+import FooterNavigation from '@/components/FooterNavigation'
+import QuickNavigation from '@/components/QuickNavigation'
+import HeroSection from '@/components/HeroSection'
+import LocationContent from '@/components/LocationContent'
+import ContactSection from '@/components/ContactSection'
+import GoogleBusinessIntegration from '@/components/GoogleBusinessIntegration'
+import LocalSEOFAQ from '@/components/LocalSEOFAQ'
+import { getProductCategories } from '@/lib/products.server'
+
+export const revalidate = 3600
+
+const CATEGORY_ICONS: Record<string, string> = {
+    Flower: 'fas fa-seedling',
+    Concentrates: 'fas fa-bong',
+    'Diamonds & Sauce': 'fas fa-gem',
+    'Vapes & Carts': 'fas fa-cloud',
+    Edibles: 'fas fa-cookie-bite',
+    'Pre-Rolls': 'fas fa-smoking',
+}
+
+export default async function ProductsPage() {
+    const categories = await getProductCategories()
+
+    return (
+        <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+            <Navigation />
+            <main id="main-content" role="main" tabIndex={-1} className="outline-none">
+                <HeroSection />
+                <section
+                    id="products"
+                    role="region"
+                    aria-labelledby="product-categories-heading"
+                    tabIndex={-1}
+                    data-section-nav
+                    className="py-16"
+                >
+                    <div className="container mx-auto px-4">
+                        <h1 id="product-categories-heading" className="mb-6 text-center text-4xl font-bold text-gray-900 dark:text-white">
+                            Shop by Category
+                        </h1>
+                        <p className="mx-auto mb-12 max-w-3xl text-center text-lg text-gray-600 dark:text-gray-300">
+                            Explore our curated THCa selection and jump directly into the product category that fits your vibe. Each section leads to live inventory with detailed sizing, pricing, and availability.
+                        </p>
+                        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+                            {categories.map((category) => {
+                                const icon = CATEGORY_ICONS[category.name] ?? 'fas fa-box-open'
+                                return (
+                                    <Link
+                                        key={category.slug}
+                                        href={`/products/${category.slug}`}
+                                        className="focus-enhanced flex h-full flex-col justify-between rounded-2xl bg-white p-6 shadow-lg transition-transform hover:-translate-y-1 hover:shadow-xl dark:bg-gray-800"
+                                    >
+                                        <div>
+                                            <div className="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-full bg-green-600 text-white">
+                                                <i className={`${icon} text-xl`} aria-hidden="true" />
+                                            </div>
+                                            <h2 className="mb-3 text-2xl font-semibold text-gray-900 dark:text-white">{category.name}</h2>
+                                            <p className="text-sm text-gray-600 dark:text-gray-300">
+                                                View all available {category.name.toLowerCase()} offerings, including size options and pricing updated hourly.
+                                            </p>
+                                        </div>
+                                        <span className="mt-6 inline-flex items-center text-sm font-semibold text-green-700 transition-colors hover:text-green-800 dark:text-green-300 dark:hover:text-green-200">
+                                            Browse {category.name}
+                                            <i className="fas fa-arrow-right ml-2 text-xs" aria-hidden="true" />
+                                        </span>
+                                    </Link>
+                                )
+                            })}
+                        </div>
+                    </div>
+                </section>
+                <LocationContent />
+                <ContactSection />
+                <GoogleBusinessIntegration />
+                <LocalSEOFAQ />
+            </main>
+            <FooterNavigation />
+            <QuickNavigation />
+        </div>
+    )
+}

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -5,8 +5,7 @@
  * call to action styles for a more contemporary feel.
  */
 import Image from 'next/image'
-
-import ScrollLink from './ScrollLink'
+import Link from 'next/link'
 
 export default function HeroSection() {
     return (
@@ -44,12 +43,12 @@ export default function HeroSection() {
                     Premium hemp products for your wellness journey.
                 </p>
                 <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
-                    <ScrollLink
-                        targetId="products"
+                    <Link
+                        href="/products"
                         className="rounded-full bg-white px-8 py-3 text-sm font-semibold text-green-800 shadow-lg transition-colors hover:bg-green-50 focus-enhanced"
                     >
                         <i className="fas fa-cannabis mr-2" /> Shop Products
-                    </ScrollLink>
+                    </Link>
                     <a
                         href="tel:+15736776418"
                         className="rounded-full border border-white/80 px-8 py-3 text-sm font-semibold text-white backdrop-blur transition-colors hover:bg-white/10 focus-enhanced"

--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useEffect, useMemo } from 'react'
+import Link from 'next/link'
 import Navigation from '@/components/Navigation'
 import FooterNavigation from '@/components/FooterNavigation'
 import QuickNavigation from '@/components/QuickNavigation'
@@ -7,27 +7,44 @@ import LocalSEOFAQ from '@/components/LocalSEOFAQ'
 import LocationContent from '@/components/LocationContent'
 import GoogleBusinessIntegration from '@/components/GoogleBusinessIntegration'
 import { useKeyboardNavigation } from '@/hooks/useNavigation'
-import { applyAutoContrast } from '@/utils/autoContrast'
 import { slugify } from '@/utils/slugify'
 import HeroSection from '@/components/HeroSection'
 import AboutSection from '@/components/AboutSection'
 import ContactSection from '@/components/ContactSection'
-import ProductSection from '@/components/ProductSection'
-import { groupProductsByCategory } from '@/lib/products'
-import type { Product } from '@/types/product'
 
-export default function HomePage({ products }: { products: Product[] }) {
+export default function HomePage() {
     useKeyboardNavigation()
 
-    const productsByCategory = useMemo(() => groupProductsByCategory(products), [products])
-
-    useEffect(() => {
-        applyAutoContrast()
-    }, [productsByCategory])
+    const productHighlights = [
+        {
+            title: 'Explore Our Full Menu',
+            description: 'Browse every THCa product we carry, from premium flower to infused treats.',
+            href: '/products',
+            icon: 'fas fa-store',
+        },
+        {
+            title: 'Fresh Flower Arrivals',
+            description: 'Discover aromatic indoor flower with rotating strains sourced from trusted growers.',
+            href: `/products/${slugify('Flower')}`,
+            icon: 'fas fa-seedling',
+        },
+        {
+            title: 'Vapes & Carts',
+            description: 'Find smooth, flavorful disposables and cartridges ready for on-the-go relief.',
+            href: `/products/${slugify('Vapes & Carts')}`,
+            icon: 'fas fa-cloud',
+        },
+        {
+            title: 'Edibles & Treats',
+            description: 'Shop gummies, baked goods, and other delicious edibles with consistent dosing.',
+            href: `/products/${slugify('Edibles')}`,
+            icon: 'fas fa-cookie-bite',
+        },
+    ]
 
     return (
         <>
-            <Navigation products={products} />
+            <Navigation />
             <main id="main-content" role="main" tabIndex={-1} className="outline-none">
                 <HeroSection />
                 <section
@@ -39,18 +56,36 @@ export default function HomePage({ products }: { products: Product[] }) {
                     className="py-16 focus:outline-none"
                 >
                     <div className="container mx-auto px-4">
-                        <h2 id="products-heading" className="mb-12 text-center text-4xl font-bold text-gray-900 dark:text-white">
-                            Our Premium Hemp Products
+                        <h2 id="products-heading" className="mb-6 text-center text-4xl font-bold text-gray-900 dark:text-white">
+                            Find Your Next Favorite Product
                         </h2>
-                        {Object.entries(productsByCategory).map(([cat, list], sectionIndex) => (
-                            <ProductSection
-                                key={cat}
-                                title={cat}
-                                products={list as Product[]}
-                                categoryId={slugify(cat)}
-                                isFirstSection={sectionIndex === 0}
-                            />
-                        ))}
+                        <p className="mx-auto mb-12 max-w-3xl text-center text-lg text-gray-600 dark:text-gray-300">
+                            Shop the Route 66 Hemp menu to explore potent THCa flower, flavorful concentrates, and craveable edibles.
+                            Jump straight into a featured category or view the entire lineup.
+                        </p>
+                        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+                            {productHighlights.map((highlight) => (
+                                <Link
+                                    key={highlight.href}
+                                    href={highlight.href}
+                                    className="focus-enhanced flex h-full flex-col justify-between rounded-2xl bg-white p-6 shadow-lg transition-transform hover:-translate-y-1 hover:shadow-xl dark:bg-gray-800"
+                                >
+                                    <div>
+                                        <div className="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-full bg-green-600 text-white">
+                                            <i className={`${highlight.icon} text-xl`} aria-hidden="true" />
+                                        </div>
+                                        <h3 className="mb-3 text-xl font-semibold text-gray-900 dark:text-white">
+                                            {highlight.title}
+                                        </h3>
+                                        <p className="text-sm text-gray-600 dark:text-gray-300">{highlight.description}</p>
+                                    </div>
+                                    <span className="mt-6 inline-flex items-center text-sm font-semibold text-green-700 transition-colors hover:text-green-800 dark:text-green-300 dark:hover:text-green-200">
+                                        View products
+                                        <i className="fas fa-arrow-right ml-2 text-xs" aria-hidden="true" />
+                                    </span>
+                                </Link>
+                            ))}
+                        </div>
                     </div>
                 </section>
                 <AboutSection />

--- a/components/QuickNavigation.tsx
+++ b/components/QuickNavigation.tsx
@@ -1,4 +1,6 @@
+'use client'
 import React, { useState, useEffect } from 'react'
+import { usePathname, useRouter } from 'next/navigation'
 
 /**
  * Renders a quick navigation component that provides quick access to
@@ -16,6 +18,8 @@ import React, { useState, useEffect } from 'react'
 function QuickNavigation() {
     const [isVisible, setIsVisible] = useState(false)
     const [activeSection, setActiveSection] = useState('')
+    const router = useRouter()
+    const pathname = usePathname()
     const focusableTabIndex = isVisible ? 0 : -1
 
     const containerClasses = [
@@ -58,11 +62,27 @@ function QuickNavigation() {
             return
         }
 
+        if (id === 'products') {
+            router.push('/products')
+            return
+        }
+
+        if (pathname !== '/') {
+            router.push(`/#${id}`)
+            return
+        }
+
         const element = document.getElementById(id)
         if (element) {
             element.scrollIntoView({ behavior: 'smooth' })
         }
     }
+
+    useEffect(() => {
+        if (pathname && pathname.startsWith('/products')) {
+            setActiveSection('products')
+        }
+    }, [pathname])
 
     return (
         <div


### PR DESCRIPTION
## Summary
- add category helpers to the product server utilities for slug-based lookups
- create /products and /products/[category] routes with reusable layout sections and product grids
- update navigation, search, hero, home, and quick navigation components to link to the new pages

## Testing
- npm run lint *(fails: ESLint circular config reference in repository setup)*

------
https://chatgpt.com/codex/tasks/task_e_68f9cd7c996c832981261eb871979baa