### PR TITLE
Add product filtering controls and tests

### DIFF
--- a/__tests__/HomePage.filters.test.tsx
+++ b/__tests__/HomePage.filters.test.tsx
@@ -1,0 +1,132 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { Product } from '@/types/product'
+import HomePage from '@/components/HomePage'
+
+jest.mock('@/hooks/useNavigation', () => ({
+    useKeyboardNavigation: jest.fn(),
+}))
+
+jest.mock('@/utils/autoContrast', () => ({
+    applyAutoContrast: jest.fn(),
+}))
+
+jest.mock('@/components/Navigation', () => () => <nav data-testid="navigation" />)
+jest.mock('@/components/FooterNavigation', () => () => <footer data-testid="footer" />)
+jest.mock('@/components/QuickNavigation', () => () => <div data-testid="quick-nav" />)
+jest.mock('@/components/LocalSEOFAQ', () => () => <section data-testid="faq" />)
+jest.mock('@/components/LocationContent', () => () => <section data-testid="location" />)
+jest.mock('@/components/GoogleBusinessIntegration', () => () => <section data-testid="google" />)
+jest.mock('@/components/HeroSection', () => () => <section data-testid="hero" />)
+jest.mock('@/components/AboutSection', () => () => <section data-testid="about" />)
+jest.mock('@/components/ContactSection', () => () => <section data-testid="contact" />)
+
+const mockProducts: Product[] = [
+    {
+        name: 'Budget Flower',
+        category: 'Flower',
+        size_options: ['1/8'],
+        prices: {
+            '1/8': 15,
+        },
+        thca_percentage: 15,
+        availability: {
+            '1/8': true,
+        },
+    },
+    {
+        name: 'Premium Flower',
+        category: 'Flower',
+        size_options: ['1/8'],
+        prices: {
+            '1/8': 60,
+        },
+        thca_percentage: 28,
+        availability: {
+            '1/8': true,
+        },
+    },
+    {
+        name: 'Unavailable Flower',
+        category: 'Flower',
+        size_options: ['1/8'],
+        prices: {
+            '1/8': 20,
+        },
+        thca_percentage: 22,
+        availability: {
+            '1/8': false,
+        },
+    },
+    {
+        name: 'Tasty Gummies',
+        category: 'Edibles',
+        size_options: ['Pack'],
+        prices: {
+            Pack: 25,
+        },
+        thca_percentage: 5,
+        availability: {
+            Pack: true,
+        },
+    },
+]
+
+const renderHomePage = () => {
+    render(<HomePage products={mockProducts} />)
+}
+
+const selectCategory = (value: string) => {
+    const selectElement = screen.getByLabelText(/Select a category/i)
+    fireEvent.change(selectElement, { target: { value } })
+}
+
+describe('HomePage filters', () => {
+    it('filters products by price range', async () => {
+        renderHomePage()
+        selectCategory('flower')
+
+        expect(await screen.findByText('Budget Flower')).toBeInTheDocument()
+        fireEvent.change(screen.getByLabelText(/Minimum price/i), { target: { value: '30' } })
+
+        expect(screen.queryByText('Budget Flower')).not.toBeInTheDocument()
+        expect(screen.getByText('Premium Flower')).toBeInTheDocument()
+    })
+
+    it('filters out unavailable products when the availability toggle is enabled', async () => {
+        renderHomePage()
+        selectCategory('flower')
+
+        expect(await screen.findByText('Unavailable Flower')).toBeInTheDocument()
+        fireEvent.click(screen.getByLabelText(/Only show in-stock items/i))
+
+        expect(screen.queryByText('Unavailable Flower')).not.toBeInTheDocument()
+        expect(screen.getByText('Premium Flower')).toBeInTheDocument()
+    })
+
+    it('filters products by potency when the potency filter is enabled', async () => {
+        renderHomePage()
+        selectCategory('flower')
+
+        expect(await screen.findByText('Budget Flower')).toBeInTheDocument()
+        fireEvent.click(screen.getByLabelText(/Enable potency range filter/i))
+        fireEvent.change(screen.getByLabelText(/Minimum potency/i), { target: { value: '26' } })
+        fireEvent.change(screen.getByLabelText(/Maximum potency/i), { target: { value: '30' } })
+
+        expect(screen.queryByText('Budget Flower')).not.toBeInTheDocument()
+        expect(screen.getByText('Premium Flower')).toBeInTheDocument()
+    })
+
+    it('shows a friendly message when no products match the filters', async () => {
+        renderHomePage()
+        selectCategory('flower')
+
+        expect(await screen.findByText('Budget Flower')).toBeInTheDocument()
+        fireEvent.change(screen.getByLabelText(/Minimum price/i), { target: { value: '100' } })
+
+        expect(
+            screen.getByText(
+                'No products match your current filters. Try widening your search or selecting another category.'
+            )
+        ).toBeInTheDocument()
+    })
+})

--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -17,6 +17,15 @@ import ProductSection from '@/components/ProductSection'
 import { groupProductsByCategory } from '@/lib/products'
 import type { Product } from '@/types/product'
 
+type FilterState = {
+    minPrice: string
+    maxPrice: string
+    onlyInStock: boolean
+    potencyEnabled: boolean
+    minPotency: number
+    maxPotency: number
+}
+
 export default function HomePage({ products }: { products: Product[] }) {
     useKeyboardNavigation()
 
@@ -37,6 +46,101 @@ export default function HomePage({ products }: { products: Product[] }) {
             null,
         [categoryEntries, selectedCategorySlug]
     )
+    const [filters, setFilters] = useState<FilterState>({
+        minPrice: '',
+        maxPrice: '',
+        onlyInStock: false,
+        potencyEnabled: false,
+        minPotency: 0,
+        maxPotency: 50,
+    })
+
+    const categoryPriceBounds = useMemo(() => {
+        if (!selectedCategory) {
+            return null
+        }
+
+        const priceValues = selectedCategory.products.flatMap((product) =>
+            Object.values(product.prices ?? {})
+                .map((value) => Number(value))
+                .filter((value) => !Number.isNaN(value))
+        )
+
+        if (priceValues.length === 0) {
+            return null
+        }
+
+        return {
+            min: Math.min(...priceValues),
+            max: Math.max(...priceValues),
+        }
+    }, [selectedCategory])
+
+    const filteredProducts = useMemo(() => {
+        if (!selectedCategory) {
+            return [] as Product[]
+        }
+
+        const { minPrice, maxPrice, onlyInStock, potencyEnabled, minPotency, maxPotency } = filters
+        const minPriceValue = minPrice !== '' ? Number(minPrice) : null
+        const maxPriceValue = maxPrice !== '' ? Number(maxPrice) : null
+        const minPotencyValue = potencyEnabled ? minPotency : null
+        const maxPotencyValue = potencyEnabled ? maxPotency : null
+
+        return selectedCategory.products.filter((product) => {
+            const priceValues = Object.values(product.prices ?? {})
+                .map((value) => Number(value))
+                .filter((value) => !Number.isNaN(value))
+
+            const matchesPrice =
+                priceValues.length === 0 ||
+                priceValues.some((price) => {
+                    if (minPriceValue !== null && price < minPriceValue) {
+                        return false
+                    }
+                    if (maxPriceValue !== null && price > maxPriceValue) {
+                        return false
+                    }
+                    return true
+                })
+
+            if (!matchesPrice) {
+                return false
+            }
+
+            if (onlyInStock) {
+                if (typeof product.availability === 'boolean') {
+                    if (!product.availability) {
+                        return false
+                    }
+                } else if (product.availability && typeof product.availability === 'object') {
+                    const availabilityValues = Object.values(product.availability)
+                    const isAvailable =
+                        availabilityValues.length === 0 || availabilityValues.some(Boolean)
+                    if (!isAvailable) {
+                        return false
+                    }
+                }
+            }
+
+            if (minPotencyValue !== null || maxPotencyValue !== null) {
+                const potencyValue =
+                    typeof product.thca_percentage === 'number'
+                        ? product.thca_percentage
+                        : null
+
+                if (minPotencyValue !== null && (potencyValue === null || potencyValue < minPotencyValue)) {
+                    return false
+                }
+
+                if (maxPotencyValue !== null && (potencyValue === null || potencyValue > maxPotencyValue)) {
+                    return false
+                }
+            }
+
+            return true
+        })
+    }, [filters, selectedCategory])
 
     useEffect(() => {
         if (typeof window === 'undefined') {
@@ -79,7 +183,7 @@ export default function HomePage({ products }: { products: Product[] }) {
         if (selectedCategory) {
             applyAutoContrast()
         }
-    }, [selectedCategory])
+    }, [filteredProducts, selectedCategory])
 
     const handleCategoryChange = (event: ChangeEvent<HTMLSelectElement>) => {
         const slug = event.target.value
@@ -94,6 +198,56 @@ export default function HomePage({ products }: { products: Product[] }) {
             )
         }
     }
+
+    const handleMinPriceChange = (event: ChangeEvent<HTMLInputElement>) => {
+        const { value } = event.target
+        setFilters((previous) => ({
+            ...previous,
+            minPrice: value,
+        }))
+    }
+
+    const handleMaxPriceChange = (event: ChangeEvent<HTMLInputElement>) => {
+        const { value } = event.target
+        setFilters((previous) => ({
+            ...previous,
+            maxPrice: value,
+        }))
+    }
+
+    const handleInStockToggle = (event: ChangeEvent<HTMLInputElement>) => {
+        const { checked } = event.target
+        setFilters((previous) => ({
+            ...previous,
+            onlyInStock: checked,
+        }))
+    }
+
+    const handlePotencyToggle = (event: ChangeEvent<HTMLInputElement>) => {
+        const { checked } = event.target
+        setFilters((previous) => ({
+            ...previous,
+            potencyEnabled: checked,
+        }))
+    }
+
+    const handleMinPotencyChange = (event: ChangeEvent<HTMLInputElement>) => {
+        const nextValue = Number(event.target.value)
+        setFilters((previous) => ({
+            ...previous,
+            minPotency: Math.min(nextValue, previous.maxPotency),
+        }))
+    }
+
+    const handleMaxPotencyChange = (event: ChangeEvent<HTMLInputElement>) => {
+        const nextValue = Number(event.target.value)
+        setFilters((previous) => ({
+            ...previous,
+            maxPotency: Math.max(nextValue, previous.minPotency),
+        }))
+    }
+
+    const filtersDisabled = !selectedCategory
 
     return (
         <>
@@ -133,14 +287,161 @@ export default function HomePage({ products }: { products: Product[] }) {
                                     </option>
                                 ))}
                             </select>
+                            <p
+                                id="product-category-help"
+                                className="mt-3 text-center text-sm text-gray-600 dark:text-gray-300"
+                            >
+                                After choosing a category you can refine the list using the filters below.
+                            </p>
+                        </div>
+                        <div className="mx-auto mb-12 max-w-4xl">
+                            <fieldset className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+                                <legend className="px-2 text-base font-semibold text-gray-900 dark:text-gray-100">
+                                    Filter products
+                                </legend>
+                                <div className="mt-4 grid gap-6 md:grid-cols-2">
+                                    <div>
+                                        <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-700 dark:text-gray-300">
+                                            Price range
+                                        </h3>
+                                        <div className="mt-4 space-y-4">
+                                            <div>
+                                                <label
+                                                    htmlFor="price-min-input"
+                                                    className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-200"
+                                                >
+                                                    Minimum price ($)
+                                                </label>
+                                                <input
+                                                    id="price-min-input"
+                                                    type="number"
+                                                    min={0}
+                                                    step={1}
+                                                    value={filters.minPrice}
+                                                    onChange={handleMinPriceChange}
+                                                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-base focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+                                                    aria-describedby="price-filter-help"
+                                                    disabled={filtersDisabled}
+                                                />
+                                            </div>
+                                            <div>
+                                                <label
+                                                    htmlFor="price-max-input"
+                                                    className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-200"
+                                                >
+                                                    Maximum price ($)
+                                                </label>
+                                                <input
+                                                    id="price-max-input"
+                                                    type="number"
+                                                    min={0}
+                                                    step={1}
+                                                    value={filters.maxPrice}
+                                                    onChange={handleMaxPriceChange}
+                                                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-base focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+                                                    aria-describedby="price-filter-help"
+                                                    disabled={filtersDisabled}
+                                                />
+                                            </div>
+                                            <p
+                                                id="price-filter-help"
+                                                className="text-sm text-gray-600 dark:text-gray-300"
+                                            >
+                                                {categoryPriceBounds
+                                                    ? `Products in this category range from $${categoryPriceBounds.min.toFixed(
+                                                          2
+                                                      )} to $${categoryPriceBounds.max.toFixed(2)}.`
+                                                    : 'Enter a minimum and maximum price to narrow the product list.'}
+                                            </p>
+                                        </div>
+                                    </div>
+                                    <div className="space-y-6">
+                                        <div>
+                                            <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-700 dark:text-gray-300">
+                                                Availability
+                                            </h3>
+                                            <label className="mt-4 flex items-center gap-3 text-sm font-medium text-gray-700 dark:text-gray-200">
+                                                <input
+                                                    type="checkbox"
+                                                    className="h-4 w-4 rounded border-gray-300 text-green-600 focus:ring-green-500"
+                                                    onChange={handleInStockToggle}
+                                                    checked={filters.onlyInStock}
+                                                    disabled={filtersDisabled}
+                                                />
+                                                Only show in-stock items
+                                            </label>
+                                        </div>
+                                        <div>
+                                            <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-700 dark:text-gray-300">
+                                                Potency (THCa %)
+                                            </h3>
+                                            <div className="mt-2 space-y-4">
+                                                <label className="flex items-center gap-3 text-sm font-medium text-gray-700 dark:text-gray-200">
+                                                    <input
+                                                        type="checkbox"
+                                                        className="h-4 w-4 rounded border-gray-300 text-green-600 focus:ring-green-500"
+                                                        onChange={handlePotencyToggle}
+                                                        checked={filters.potencyEnabled}
+                                                        disabled={filtersDisabled}
+                                                    />
+                                                    Enable potency range filter
+                                                </label>
+                                                <div className="space-y-4" aria-disabled={!filters.potencyEnabled || filtersDisabled}>
+                                                    <div>
+                                                        <label
+                                                            htmlFor="potency-min-input"
+                                                            className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-200"
+                                                        >
+                                                            Minimum potency: <span className="font-semibold">{filters.minPotency}%</span>
+                                                        </label>
+                                                        <input
+                                                            id="potency-min-input"
+                                                            type="range"
+                                                            min={0}
+                                                            max={50}
+                                                            step={1}
+                                                            value={filters.minPotency}
+                                                            onChange={handleMinPotencyChange}
+                                                            className="w-full"
+                                                            disabled={filtersDisabled || !filters.potencyEnabled}
+                                                            aria-valuetext={`${filters.minPotency}%`}
+                                                        />
+                                                    </div>
+                                                    <div>
+                                                        <label
+                                                            htmlFor="potency-max-input"
+                                                            className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-200"
+                                                        >
+                                                            Maximum potency: <span className="font-semibold">{filters.maxPotency}%</span>
+                                                        </label>
+                                                        <input
+                                                            id="potency-max-input"
+                                                            type="range"
+                                                            min={0}
+                                                            max={50}
+                                                            step={1}
+                                                            value={filters.maxPotency}
+                                                            onChange={handleMaxPotencyChange}
+                                                            className="w-full"
+                                                            disabled={filtersDisabled || !filters.potencyEnabled}
+                                                            aria-valuetext={`${filters.maxPotency}%`}
+                                                        />
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
                         </div>
                         {selectedCategory ? (
                             <ProductSection
                                 key={selectedCategory.slug}
                                 title={selectedCategory.name}
-                                products={selectedCategory.products}
+                                products={filteredProducts}
                                 categoryId={selectedCategory.slug}
                                 isFirstSection
+                                emptyMessage="No products match your current filters. Try widening your search or selecting another category."
                             />
                         ) : (
                             <p className="text-center text-lg text-gray-700 dark:text-gray-300">

--- a/components/ProductSection.tsx
+++ b/components/ProductSection.tsx
@@ -6,13 +6,19 @@ interface ProductSectionProps {
     products: Product[]
     categoryId: string
     isFirstSection?: boolean
+    emptyMessage?: string
 }
 
-export default function ProductSection({ title, products, categoryId, isFirstSection = false }: ProductSectionProps) {
-    if (!products || products.length === 0) return null
-
+export default function ProductSection({
+    title,
+    products,
+    categoryId,
+    isFirstSection = false,
+    emptyMessage = 'No products available in this category at the moment.',
+}: ProductSectionProps) {
+    const hasProducts = Array.isArray(products) && products.length > 0
     const headingId = [categoryId, 'heading'].join('-')
-    const totalItems = products.length
+    const totalItems = hasProducts ? products.length : 0
 
     return (
         <section
@@ -30,24 +36,30 @@ export default function ProductSection({ title, products, categoryId, isFirstSec
                 >
                     {title}
                 </h2>
-                <ul
-                    className="grid list-none grid-cols-1 items-stretch gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 sm:justify-items-start"
-                    role="list"
-                    aria-labelledby={headingId}
-                    data-product-grid
-                >
-                    {products.map((product, index) => (
-                        <li key={product.name} className="list-none h-full">
-                            <ProductCard
-                                product={product}
-                                priority={isFirstSection && index === 0}
-                                gridIndex={index}
-                                gridSize={totalItems}
-                                parentHeadingId={headingId}
-                            />
-                        </li>
-                    ))}
-                </ul>
+                {hasProducts ? (
+                    <ul
+                        className="grid list-none grid-cols-1 items-stretch gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 sm:justify-items-start"
+                        role="list"
+                        aria-labelledby={headingId}
+                        data-product-grid
+                    >
+                        {products.map((product, index) => (
+                            <li key={product.name} className="list-none h-full">
+                                <ProductCard
+                                    product={product}
+                                    priority={isFirstSection && index === 0}
+                                    gridIndex={index}
+                                    gridSize={totalItems}
+                                    parentHeadingId={headingId}
+                                />
+                            </li>
+                        ))}
+                    </ul>
+                ) : (
+                    <p className="text-center text-lg text-gray-700 dark:text-gray-300" role="status">
+                        {emptyMessage}
+                    </p>
+                )}
             </div>
         </section>
     )


### PR DESCRIPTION
## Summary
- add interactive price, availability, and potency filters to the home page product listing
- derive a filtered product list and show an empty state when no products match
- cover filtering behaviour with component tests

## Testing
- npm run test_jest -- HomePage.filters

------
https://chatgpt.com/codex/tasks/task_e_69070b7e81188329ab9e65786daa0002