### PR TITLE
Add product sorting controls to homepage

### DIFF
--- a/__tests__/products.sorting.test.ts
+++ b/__tests__/products.sorting.test.ts
@@ -1,0 +1,109 @@
+import { getMinimumProductPrice, sortProductsByOrder } from '@/lib/products'
+import type { Product } from '@/types/product'
+
+describe('product sorting helpers', () => {
+    const baseProduct: Product = {
+        name: 'Base Product',
+        category: 'Category',
+        size_options: ['1g'],
+        prices: { standard: 10 },
+    }
+
+    it('computes the minimum price across size options', () => {
+        const product: Product = {
+            ...baseProduct,
+            name: 'Multi Size',
+            prices: {
+                eighth: 35,
+                gram: 12,
+                quarter: 60,
+            },
+        }
+
+        expect(getMinimumProductPrice(product)).toBe(12)
+    })
+
+    it('returns null when no prices are available', () => {
+        const product: Product = {
+            ...baseProduct,
+            name: 'No Price',
+            prices: {},
+        }
+
+        expect(getMinimumProductPrice(product)).toBeNull()
+    })
+
+    it('sorts products by their minimum price in ascending order', () => {
+        const products: Product[] = [
+            {
+                ...baseProduct,
+                name: 'Premium',
+                prices: {
+                    eighth: 55,
+                    gram: 20,
+                },
+            },
+            {
+                ...baseProduct,
+                name: 'Budget',
+                prices: {
+                    gram: 10,
+                    quarter: 35,
+                },
+            },
+            {
+                ...baseProduct,
+                name: 'Standard',
+                prices: {
+                    gram: 15,
+                    eighth: 40,
+                },
+            },
+        ]
+
+        const sorted = sortProductsByOrder(products, 'price-asc')
+
+        expect(sorted.map((product) => product.name)).toEqual([
+            'Budget',
+            'Standard',
+            'Premium',
+        ])
+    })
+
+    it('sorts products by their minimum price in descending order', () => {
+        const products: Product[] = [
+            {
+                ...baseProduct,
+                name: 'Premium',
+                prices: {
+                    eighth: 55,
+                    gram: 20,
+                },
+            },
+            {
+                ...baseProduct,
+                name: 'Budget',
+                prices: {
+                    gram: 10,
+                    quarter: 35,
+                },
+            },
+            {
+                ...baseProduct,
+                name: 'Standard',
+                prices: {
+                    gram: 15,
+                    eighth: 40,
+                },
+            },
+        ]
+
+        const sorted = sortProductsByOrder(products, 'price-desc')
+
+        expect(sorted.map((product) => product.name)).toEqual([
+            'Premium',
+            'Standard',
+            'Budget',
+        ])
+    })
+})

--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -14,7 +14,8 @@ import HeroSection from '@/components/HeroSection'
 import AboutSection from '@/components/AboutSection'
 import ContactSection from '@/components/ContactSection'
 import ProductSection from '@/components/ProductSection'
-import { groupProductsByCategory } from '@/lib/products'
+import { groupProductsByCategory, sortProductsByOrder } from '@/lib/products'
+import type { ProductSortOrder } from '@/lib/products'
 import type { Product } from '@/types/product'
 
 type FilterState = {
@@ -40,6 +41,7 @@ export default function HomePage({ products }: { products: Product[] }) {
         [productsByCategory]
     )
     const [selectedCategorySlug, setSelectedCategorySlug] = useState<string>('')
+    const [sortOrder, setSortOrder] = useState<ProductSortOrder>('featured')
     const selectedCategory = useMemo(
         () =>
             categoryEntries.find((entry) => entry.slug === selectedCategorySlug) ??
@@ -142,6 +144,11 @@ export default function HomePage({ products }: { products: Product[] }) {
         })
     }, [filters, selectedCategory])
 
+    const sortedProducts = useMemo(
+        () => sortProductsByOrder(filteredProducts, sortOrder),
+        [filteredProducts, sortOrder]
+    )
+
     useEffect(() => {
         if (typeof window === 'undefined') {
             return
@@ -183,7 +190,7 @@ export default function HomePage({ products }: { products: Product[] }) {
         if (selectedCategory) {
             applyAutoContrast()
         }
-    }, [filteredProducts, selectedCategory])
+    }, [selectedCategory, sortedProducts])
 
     const handleCategoryChange = (event: ChangeEvent<HTMLSelectElement>) => {
         const slug = event.target.value
@@ -197,6 +204,10 @@ export default function HomePage({ products }: { products: Product[] }) {
                 })
             )
         }
+    }
+
+    const handleSortOrderChange = (event: ChangeEvent<HTMLSelectElement>) => {
+        setSortOrder(event.target.value as ProductSortOrder)
     }
 
     const handleMinPriceChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -295,6 +306,25 @@ export default function HomePage({ products }: { products: Product[] }) {
                             </p>
                         </div>
                         <div className="mx-auto mb-12 max-w-4xl">
+                            <div className="mb-8">
+                                <label
+                                    htmlFor="product-sort-select"
+                                    className="mb-2 block text-center text-lg font-semibold text-gray-800 dark:text-gray-200"
+                                >
+                                    Sort products
+                                </label>
+                                <select
+                                    id="product-sort-select"
+                                    value={sortOrder}
+                                    onChange={handleSortOrderChange}
+                                    className="w-full rounded-md border border-gray-300 bg-white px-4 py-3 text-base shadow-sm focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+                                    disabled={filtersDisabled}
+                                >
+                                    <option value="featured">Featured</option>
+                                    <option value="price-asc">Price: Low to High</option>
+                                    <option value="price-desc">Price: High to Low</option>
+                                </select>
+                            </div>
                             <fieldset className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
                                 <legend className="px-2 text-base font-semibold text-gray-900 dark:text-gray-100">
                                     Filter products
@@ -438,7 +468,7 @@ export default function HomePage({ products }: { products: Product[] }) {
                             <ProductSection
                                 key={selectedCategory.slug}
                                 title={selectedCategory.name}
-                                products={filteredProducts}
+                                products={sortedProducts}
                                 categoryId={selectedCategory.slug}
                                 isFirstSection
                                 emptyMessage="No products match your current filters. Try widening your search or selecting another category."

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -1,25 +1,90 @@
 import type { Product, ProductMap } from '@/types/product'
 
-function sortProducts(products: Product[]): Product[] {
-  const priority = (product: Product): number => {
-    switch (product.banner) {
-      case 'New':
-        return 0
-      case 'Out of Stock':
-        return 2
-      default:
-        return 1
-    }
+type ProductSortPriority = 'featured' | 'price-asc' | 'price-desc'
+
+function getProductPriority(product: Product): number {
+  switch (product.banner) {
+    case 'New':
+      return 0
+    case 'Out of Stock':
+      return 2
+    default:
+      return 1
+  }
+}
+
+function compareByFeatured(a: Product, b: Product): number {
+  const priorityDelta = getProductPriority(a) - getProductPriority(b)
+  if (priorityDelta !== 0) {
+    return priorityDelta
   }
 
-  return [...products].sort((a, b) => {
-    const priorityDelta = priority(a) - priority(b)
-    if (priorityDelta !== 0) {
-      return priorityDelta
+  return a.name.localeCompare(b.name)
+}
+
+function getProductPrices(product: Product): number[] {
+  return Object.values(product.prices ?? {})
+    .map((value) => Number(value))
+    .filter((value) => !Number.isNaN(value))
+}
+
+export function getMinimumProductPrice(product: Product): number | null {
+  const prices = getProductPrices(product)
+
+  if (prices.length === 0) {
+    return null
+  }
+
+  return Math.min(...prices)
+}
+
+function compareByPrice(order: Exclude<ProductSortPriority, 'featured'>) {
+  return (a: Product, b: Product): number => {
+    const minPriceA = getMinimumProductPrice(a)
+    const minPriceB = getMinimumProductPrice(b)
+
+    if (minPriceA === null && minPriceB === null) {
+      return compareByFeatured(a, b)
     }
 
-    return a.name.localeCompare(b.name)
-  })
+    if (minPriceA === null) {
+      return 1
+    }
+
+    if (minPriceB === null) {
+      return -1
+    }
+
+    const priceDelta =
+      order === 'price-asc' ? minPriceA - minPriceB : minPriceB - minPriceA
+
+    if (priceDelta !== 0) {
+      return priceDelta
+    }
+
+    return compareByFeatured(a, b)
+  }
+}
+
+function sortProducts(products: Product[]): Product[] {
+  return [...products].sort(compareByFeatured)
+}
+
+export type ProductSortOrder = ProductSortPriority
+
+export function sortProductsByOrder(
+  products: Product[],
+  order: ProductSortOrder
+): Product[] {
+  switch (order) {
+    case 'price-asc':
+      return [...products].sort(compareByPrice('price-asc'))
+    case 'price-desc':
+      return [...products].sort(compareByPrice('price-desc'))
+    case 'featured':
+    default:
+      return sortProducts(products)
+  }
 }
 
 export function groupProductsByCategory(products: Product[]): ProductMap {


### PR DESCRIPTION
## Summary
- introduce sort order state and UI on the homepage to apply sorting alongside existing filters
- add reusable helpers for computing minimum product price and sorting product lists by featured or price order
- cover the new sorting utilities with unit tests to confirm price ordering across size options

## Testing
- npm run test_jest -- --runTestsByPath __tests__/products.sorting.test.ts

------
https://chatgpt.com/codex/tasks/task_e_69070f14e6f083298a14e8ef77ee735f