### PR TITLE
Add curated product rails and marketing highlights

### DIFF
--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -13,9 +13,16 @@ import AboutSection from '@/components/AboutSection'
 import ContactSection from '@/components/ContactSection'
 import HeroSection from '@/components/HeroSection'
 import ProductSection from '@/components/ProductSection'
+import ProductCarousel from '@/components/ProductCarousel'
+import MarketingHighlights from '@/components/MarketingHighlights'
 import FilterPanel, { type FilterState } from '@/components/FilterPanel'
-import { groupProductsByCategory, sortProductsByOrder } from '@/lib/products'
+import {
+    buildCuratedCollections,
+    groupProductsByCategory,
+    sortProductsByOrder,
+} from '@/lib/products'
 import type { ProductSortOrder } from '@/lib/products'
+import { MARKETING_BLOCKS } from '@/lib/marketing'
 import { applyAutoContrast } from '@/utils/autoContrast'
 import { slugify } from '@/utils/slugify'
 import type { Product } from '@/types/product'
@@ -47,6 +54,9 @@ export default function HomePage({ products, initialCategory }: HomePageProps) {
     const [isFilterDrawerOpen, setIsFilterDrawerOpen] = useState(false)
 
     const productsByCategory = useMemo(() => groupProductsByCategory(products), [products])
+
+    const curatedCollections = useMemo(() => buildCuratedCollections(products, 10), [products])
+    const { featured, newArrivals, bestsellers } = curatedCollections
 
     const categoryEntries = useMemo<CategoryEntry[]>(
         () =>
@@ -333,6 +343,23 @@ export default function HomePage({ products, initialCategory }: HomePageProps) {
             <Navigation />
             <main id="main-content" role="main" tabIndex={-1} className="outline-none">
                 <HeroSection />
+                {featured.length > 0 ? (
+                    <ProductCarousel
+                        title="Featured Favorites"
+                        description="Hand-picked strains and goods our team can't stop talking about."
+                        sectionId="featured-products"
+                        products={featured}
+                        cta={{ label: 'Browse full menu', href: '#products' }}
+                    />
+                ) : null}
+                {newArrivals.length > 0 ? (
+                    <ProductCarousel
+                        title="Fresh on the Shelf"
+                        description="Discover the latest drops before they disappear."
+                        sectionId="new-arrivals"
+                        products={newArrivals}
+                    />
+                ) : null}
                 <section
                     id="products"
                     role="region"
@@ -434,6 +461,16 @@ export default function HomePage({ products, initialCategory }: HomePageProps) {
                         )}
                     </div>
                 </section>
+                <MarketingHighlights blocks={MARKETING_BLOCKS} />
+                {bestsellers.length > 0 ? (
+                    <ProductCarousel
+                        title="Route 66 Bestsellers"
+                        description="Fan-favorite picks with unbeatable value and consistency."
+                        sectionId="bestsellers"
+                        products={bestsellers}
+                        cta={{ label: 'Shop top sellers', href: '#products' }}
+                    />
+                ) : null}
                 <AboutSection />
                 <LocationContent />
                 <ContactSection />

--- a/components/MarketingHighlights.tsx
+++ b/components/MarketingHighlights.tsx
@@ -1,0 +1,47 @@
+import type { MarketingBlock } from '@/lib/marketing'
+
+interface MarketingHighlightsProps {
+    blocks: MarketingBlock[]
+}
+
+export default function MarketingHighlights({ blocks }: MarketingHighlightsProps) {
+    if (!blocks || blocks.length === 0) {
+        return null
+    }
+
+    return (
+        <section className="py-12">
+            <div className="container mx-auto px-4">
+                <div className="grid gap-6 md:grid-cols-2">
+                    {blocks.map((block) => (
+                        <article
+                            key={block.id}
+                            className="focus-enhanced group flex h-full flex-col justify-between rounded-2xl border border-green-100 bg-gradient-to-br from-green-50 via-white to-white p-6 text-left shadow-sm transition hover:-translate-y-1 hover:shadow-lg dark:border-green-900/40 dark:from-gray-900 dark:via-gray-950 dark:to-gray-900"
+                        >
+                            <div className="space-y-3">
+                                {block.eyebrow ? (
+                                    <p className="text-xs font-semibold uppercase tracking-wide text-green-700 dark:text-green-300">
+                                        {block.eyebrow}
+                                    </p>
+                                ) : null}
+                                <h3 className="text-2xl font-bold text-gray-900 transition-colors group-hover:text-green-700 dark:text-white">
+                                    {block.title}
+                                </h3>
+                                <p className="text-base text-gray-600 dark:text-gray-300">{block.description}</p>
+                            </div>
+                            {block.cta ? (
+                                <a
+                                    href={block.cta.href}
+                                    className="mt-6 inline-flex items-center text-sm font-semibold text-green-700 transition hover:text-green-800 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:text-green-300 dark:hover:text-green-200 dark:focus:ring-offset-gray-900"
+                                >
+                                    {block.cta.label}
+                                    <span aria-hidden="true" className="ml-2">→</span>
+                                </a>
+                            ) : null}
+                        </article>
+                    ))}
+                </div>
+            </div>
+        </section>
+    )
+}

--- a/components/ProductCarousel.tsx
+++ b/components/ProductCarousel.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { useId, useRef } from 'react'
+import ProductCard from '@/components/ProductCard'
+import type { Product } from '@/types/product'
+import { slugify } from '@/utils/slugify'
+
+interface CarouselCta {
+    label: string
+    href: string
+}
+
+interface ProductCarouselProps {
+    title: string
+    products: Product[]
+    description?: string
+    sectionId?: string
+    cta?: CarouselCta
+}
+
+const SCROLL_STEP = 320
+
+export default function ProductCarousel({ title, products, description, sectionId, cta }: ProductCarouselProps) {
+    const listRef = useRef<HTMLDivElement>(null)
+    const generatedId = useId()
+    const resolvedSectionId = sectionId ?? slugify(`${title}-${generatedId}`)
+    const headingId = `${resolvedSectionId}-heading`
+    const descriptionId = description ? `${resolvedSectionId}-description` : undefined
+    const listId = `${resolvedSectionId}-list`
+
+    if (!products || products.length === 0) {
+        return null
+    }
+
+    const handleScroll = (direction: 'left' | 'right') => {
+        const container = listRef.current
+        if (!container) {
+            return
+        }
+
+        const delta = direction === 'left' ? -SCROLL_STEP : SCROLL_STEP
+        container.scrollBy({ left: delta, behavior: 'smooth' })
+    }
+
+    return (
+        <section
+            id={resolvedSectionId}
+            aria-labelledby={headingId}
+            aria-describedby={descriptionId}
+            className="py-12"
+            data-section-nav
+        >
+            <div className="container mx-auto px-4">
+                <div className="mb-6 flex flex-wrap items-end justify-between gap-4">
+                    <div className="max-w-2xl space-y-2">
+                        <h2 id={headingId} className="text-2xl font-bold text-gray-900 dark:text-white">
+                            {title}
+                        </h2>
+                        {description ? (
+                            <p id={descriptionId} className="text-base text-gray-600 dark:text-gray-300">
+                                {description}
+                            </p>
+                        ) : null}
+                    </div>
+                    <div className="flex items-center gap-3">
+                        <button
+                            type="button"
+                            onClick={() => handleScroll('left')}
+                            className="focus-enhanced inline-flex h-10 w-10 items-center justify-center rounded-full border border-gray-300 text-gray-700 transition hover:border-green-500 hover:text-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:border-gray-600 dark:text-gray-200 dark:hover:border-green-400 dark:hover:text-green-300 dark:focus:ring-offset-gray-900"
+                            aria-controls={listId}
+                            aria-label={`Scroll ${title} carousel backward`}
+                        >
+                            <span aria-hidden="true">&#8592;</span>
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => handleScroll('right')}
+                            className="focus-enhanced inline-flex h-10 w-10 items-center justify-center rounded-full border border-gray-300 text-gray-700 transition hover:border-green-500 hover:text-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:border-gray-600 dark:text-gray-200 dark:hover:border-green-400 dark:hover:text-green-300 dark:focus:ring-offset-gray-900"
+                            aria-controls={listId}
+                            aria-label={`Scroll ${title} carousel forward`}
+                        >
+                            <span aria-hidden="true">&#8594;</span>
+                        </button>
+                        {cta ? (
+                            <a
+                                href={cta.href}
+                                className="focus-enhanced inline-flex items-center justify-center rounded-full border border-green-600 px-4 py-2 text-sm font-semibold text-green-700 transition hover:bg-green-600 hover:text-white dark:text-green-300"
+                            >
+                                {cta.label}
+                            </a>
+                        ) : null}
+                    </div>
+                </div>
+                <div className="relative">
+                    <div
+                        id={listId}
+                        ref={listRef}
+                        role="list"
+                        className="flex snap-x snap-mandatory gap-4 overflow-x-auto pb-4"
+                        aria-label={title}
+                    >
+                        {products.map((product, index) => (
+                            <div key={product.name} role="listitem" className="snap-start">
+                                <ProductCard
+                                    product={product}
+                                    gridIndex={index}
+                                    gridSize={products.length}
+                                    variant="compact"
+                                />
+                            </div>
+                        ))}
+                    </div>
+                    <div className="pointer-events-none absolute inset-y-0 left-0 w-10 bg-gradient-to-r from-white to-transparent dark:from-gray-950" />
+                    <div className="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-white to-transparent dark:from-gray-950" />
+                </div>
+            </div>
+        </section>
+    )
+}

--- a/lib/marketing.ts
+++ b/lib/marketing.ts
@@ -1,0 +1,35 @@
+export interface MarketingBlock {
+    id: string
+    eyebrow?: string
+    title: string
+    description: string
+    cta?: {
+        label: string
+        href: string
+    }
+}
+
+export const MARKETING_BLOCKS: MarketingBlock[] = [
+    {
+        id: 'loyalty',
+        eyebrow: 'Loyalty Rewards',
+        title: 'Join the Route 66 Loyalty Club',
+        description:
+            'Earn points with every purchase, unlock exclusive savings, and receive early access to our limited drops.',
+        cta: {
+            label: 'Sign up & save',
+            href: '/loyalty',
+        },
+    },
+    {
+        id: 'store-pickup',
+        eyebrow: 'In-Store Pickup',
+        title: 'Reserve online, pick up in minutes',
+        description:
+            'Browse the menu, reserve your favorites, and swing by the shop when it suits your schedule—no waiting required.',
+        cta: {
+            label: 'View pickup details',
+            href: '/pickup',
+        },
+    },
+]

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -2,6 +2,8 @@ import type { Product, ProductMap } from '@/types/product'
 
 type ProductSortPriority = 'featured' | 'price-asc' | 'price-desc'
 
+const CURATED_LIMIT = 12
+
 function getProductPriority(product: Product): number {
   switch (product.banner) {
     case 'New':
@@ -36,6 +38,17 @@ export function getMinimumProductPrice(product: Product): number | null {
   }
 
   return Math.min(...prices)
+}
+
+function getAverageProductPrice(product: Product): number | null {
+  const prices = getProductPrices(product)
+
+  if (prices.length === 0) {
+    return null
+  }
+
+  const total = prices.reduce((sum, value) => sum + value, 0)
+  return total / prices.length
 }
 
 function compareByPrice(order: Exclude<ProductSortPriority, 'featured'>) {
@@ -105,3 +118,134 @@ export function groupProductsByCategory(products: Product[]): ProductMap {
 }
 
 export { sortProducts }
+
+function dedupeProducts(products: Product[]): Product[] {
+  const seen = new Set<string>()
+  const result: Product[] = []
+
+  for (const product of products) {
+    const key = product.name.toLowerCase()
+    if (seen.has(key)) {
+      continue
+    }
+    seen.add(key)
+    result.push(product)
+  }
+
+  return result
+}
+
+function limitProducts(products: Product[], limit: number): Product[] {
+  if (products.length <= limit) {
+    return products
+  }
+
+  return products.slice(0, limit)
+}
+
+function sortByAveragePriceDesc(products: Product[]): Product[] {
+  return [...products].sort((a, b) => {
+    const avgPriceA = getAverageProductPrice(a)
+    const avgPriceB = getAverageProductPrice(b)
+
+    if (avgPriceA === null && avgPriceB === null) {
+      return compareByFeatured(a, b)
+    }
+
+    if (avgPriceA === null) {
+      return 1
+    }
+
+    if (avgPriceB === null) {
+      return -1
+    }
+
+    const delta = avgPriceB - avgPriceA
+    if (delta !== 0) {
+      return delta
+    }
+
+    return compareByFeatured(a, b)
+  })
+}
+
+function sortByMinimumPriceAsc(products: Product[]): Product[] {
+  return [...products].sort((a, b) => {
+    const minPriceA = getMinimumProductPrice(a)
+    const minPriceB = getMinimumProductPrice(b)
+
+    if (minPriceA === null && minPriceB === null) {
+      return compareByFeatured(a, b)
+    }
+
+    if (minPriceA === null) {
+      return 1
+    }
+
+    if (minPriceB === null) {
+      return -1
+    }
+
+    const delta = minPriceA - minPriceB
+    if (delta !== 0) {
+      return delta
+    }
+
+    return compareByFeatured(a, b)
+  })
+}
+
+function filterAvailableProducts(products: Product[]): Product[] {
+  return products.filter((product) => product.banner !== 'Out of Stock')
+}
+
+export function getFeaturedProducts(
+  products: Product[],
+  limit: number = CURATED_LIMIT
+): Product[] {
+  const bannerMatches = products.filter((product) =>
+    product.banner ? ['Featured', 'Staff Pick', 'Editor\'s Pick'].includes(product.banner) : false
+  )
+
+  const highlighted = bannerMatches.length > 0 ? bannerMatches : filterAvailableProducts(products)
+  const sorted = sortByAveragePriceDesc(highlighted)
+
+  return limitProducts(dedupeProducts(sorted), limit)
+}
+
+export function getNewArrivals(
+  products: Product[],
+  limit: number = CURATED_LIMIT
+): Product[] {
+  const newItems = products.filter((product) => product.banner === 'New')
+  const sorted = sortProducts(newItems)
+
+  return limitProducts(sorted, limit)
+}
+
+export function getBestsellers(
+  products: Product[],
+  limit: number = CURATED_LIMIT
+): Product[] {
+  const availableProducts = filterAvailableProducts(products)
+  const sorted = sortByMinimumPriceAsc(availableProducts)
+
+  return limitProducts(sorted, limit)
+}
+
+export interface CuratedCollections {
+  featured: Product[]
+  newArrivals: Product[]
+  bestsellers: Product[]
+}
+
+export function buildCuratedCollections(
+  products: Product[],
+  limit: number = CURATED_LIMIT
+): CuratedCollections {
+  return {
+    featured: getFeaturedProducts(products, limit),
+    newArrivals: getNewArrivals(products, limit),
+    bestsellers: getBestsellers(products, limit),
+  }
+}


### PR DESCRIPTION
## Summary
- add curated product utilities for featured, new, and bestseller groupings
- build reusable product carousel rail and marketing highlight components
- wire curated rails and marketing content into the homepage experience

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6907d7baf03c83299492bed85ea2965c