### PR TITLE
Improve policy page contrast and link styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -295,22 +295,36 @@ button {
 
 /* Ensure readable text on legal policy pages */
 .policy-content {
+  background-color: var(--color-bg-primary);
   color: var(--color-text-primary);
+  line-height: 1.7;
 }
 
 .policy-content a {
-  color: var(--color-secondary);
+  color: #0f766e;
+  font-weight: 600;
   text-decoration: underline;
   text-underline-offset: 2px;
+  transition: color 0.2s ease-in-out;
 }
 
 .policy-content a:hover {
-  color: var(--color-secondary-hover);
+  color: #0b5c52;
 }
 
+.dark .policy-content,
 @media (prefers-color-scheme: dark) {
   .policy-content {
     color: var(--color-text-primary);
+    background-color: var(--color-bg-primary);
+  }
+
+  .policy-content a {
+    color: #7dd3fc;
+  }
+
+  .policy-content a:hover {
+    color: #38bdf8;
   }
 }
 

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -39,10 +39,7 @@ export default function PrivacyPolicyPage() {
         </p>
         <p className="mt-8">
           For questions about this policy, email us at{' '}
-          <a
-            href="mailto:route66hemp@gmail.com"
-            className="text-blue-600 underline dark:text-blue-400"
-          >
+          <a href="mailto:route66hemp@gmail.com">
             route66hemp@gmail.com
           </a>
           .

--- a/app/terms-of-service/page.tsx
+++ b/app/terms-of-service/page.tsx
@@ -20,7 +20,7 @@ export default function TermsOfServicePage() {
         <h2 className="mb-2 mt-6 text-2xl font-semibold">Privacy</h2>
         <p className="mb-4">
           Our{' '}
-          <a href="/privacy-policy" className="text-blue-600 underline dark:text-blue-400">
+          <a href="/privacy-policy">
             Privacy Policy
           </a>{' '}
           describes how we collect, use, and share your information. By
@@ -73,10 +73,7 @@ export default function TermsOfServicePage() {
         </p>
         <p className="mt-8">
           If you have questions about these Terms, please contact us at{' '}
-          <a
-            href="mailto:route66hemp@gmail.com"
-            className="text-blue-600 underline dark:text-blue-400"
-          >
+          <a href="mailto:route66hemp@gmail.com">
             route66hemp@gmail.com
           </a>
           .


### PR DESCRIPTION
## Summary
- add high-contrast backgrounds and link styles to shared policy-content container for both light and dark themes
- ensure privacy policy and terms pages rely on shared styling instead of inline color utilities

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691eb1971fc88329a6463b84623746cc)