### PR TITLE
Add Clover checkout API integration and cart submission

### DIFF
--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -1,0 +1,279 @@
+import { NextRequest, NextResponse } from 'next/server'
+import getConfig from 'next/config'
+import {
+    buildCartHash,
+    validateCartPayload,
+    verifyWebhookSignature,
+} from '../../../lib/checkout-utils.mjs'
+import {
+    findTransactionByHash,
+    recordTransaction,
+    updateTransactionStatus,
+} from '../../../lib/transaction-store'
+
+interface CloverConfig {
+    merchantId: string
+    apiKey: string
+    baseUrl: string
+    webhookSecret?: string
+    allowedOrigins?: string
+}
+
+const { serverRuntimeConfig } = getConfig()
+const cloverConfig: CloverConfig = {
+    merchantId:
+        serverRuntimeConfig?.clover?.merchantId ||
+        process.env.CLOVER_MERCHANT_ID ||
+        '',
+    apiKey:
+        serverRuntimeConfig?.clover?.apiKey || process.env.CLOVER_API_KEY || '',
+    baseUrl:
+        serverRuntimeConfig?.clover?.baseUrl ||
+        process.env.CLOVER_BASE_URL ||
+        'https://sandbox.dev.clover.com',
+    webhookSecret:
+        serverRuntimeConfig?.clover?.webhookSecret ||
+        process.env.CLOVER_WEBHOOK_SECRET,
+    allowedOrigins:
+        serverRuntimeConfig?.clover?.allowedOrigins ||
+        process.env.CLOVER_ALLOWED_ORIGINS,
+}
+
+function enforceHttps(req: NextRequest) {
+    if (process.env.NODE_ENV === 'production') {
+        const protocol = req.nextUrl.protocol
+        if (protocol !== 'https:') {
+            return NextResponse.json(
+                { error: 'HTTPS is required.' },
+                {
+                    status: 400,
+                }
+            )
+        }
+    }
+    return null
+}
+
+function enforceOrigin(req: NextRequest) {
+    const origins = (cloverConfig.allowedOrigins || '')
+        .split(',')
+        .map((origin) => origin.trim())
+        .filter(Boolean)
+    if (origins.length === 0) return null
+
+    const requestOrigin = req.headers.get('origin')
+    if (!requestOrigin || !origins.includes(requestOrigin)) {
+        return NextResponse.json(
+            { error: 'Origin not allowed.' },
+            {
+                status: 403,
+            }
+        )
+    }
+
+    return null
+}
+
+async function createCloverOrder({
+    items,
+    currency,
+    total,
+    customer,
+    shipping,
+}: {
+    items: Array<{ variantId: string; name: string; qty: number; unitPrice: number }>
+    currency: string
+    total: number
+    customer: Record<string, unknown>
+    shipping: Record<string, unknown>
+}) {
+    const orderUrl = `${cloverConfig.baseUrl}/v3/merchants/${cloverConfig.merchantId}/orders`
+    const response = await fetch(orderUrl, {
+        method: 'POST',
+        headers: {
+            Authorization: `Bearer ${cloverConfig.apiKey}`,
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            state: 'open',
+            currency,
+            total,
+            lineItems: items.map((item) => ({
+                name: item.name,
+                price: item.unitPrice,
+                quantity: item.qty,
+            })),
+            metadata: {
+                customer,
+                shipping,
+            },
+        }),
+    })
+
+    if (!response.ok) {
+        const text = await response.text()
+        throw new Error(`Clover order failed: ${text}`)
+    }
+
+    return response.json()
+}
+
+async function createCloverPayment({
+    orderId,
+    total,
+    currency,
+}: {
+    orderId: string
+    total: number
+    currency: string
+}) {
+    const paymentUrl = `${cloverConfig.baseUrl}/v3/merchants/${cloverConfig.merchantId}/payments`
+    const response = await fetch(paymentUrl, {
+        method: 'POST',
+        headers: {
+            Authorization: `Bearer ${cloverConfig.apiKey}`,
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            orderId,
+            amount: total,
+            currency,
+        }),
+    })
+
+    if (!response.ok) {
+        const text = await response.text()
+        throw new Error(`Clover payment failed: ${text}`)
+    }
+
+    return response.json()
+}
+
+async function handleCheckout(req: NextRequest) {
+    if (!cloverConfig.apiKey || !cloverConfig.merchantId) {
+        return NextResponse.json(
+            { error: 'Clover credentials are not configured.' },
+            { status: 500 }
+        )
+    }
+
+    const httpsError = enforceHttps(req)
+    if (httpsError) return httpsError
+
+    const originError = enforceOrigin(req)
+    if (originError) return originError
+
+    let payload: any
+    try {
+        payload = await req.json()
+    } catch (error) {
+        return NextResponse.json(
+            { error: 'Invalid JSON payload.' },
+            { status: 400 }
+        )
+    }
+
+    try {
+        const { items, total, currency, customer, shipping } =
+            validateCartPayload(payload)
+
+        const cartHash = buildCartHash(payload)
+        const existing = await findTransactionByHash(cartHash)
+        if (existing) {
+            return NextResponse.json({
+                orderId: existing.orderId,
+                paymentId: existing.paymentId,
+                status: existing.status,
+            })
+        }
+
+        const order = await createCloverOrder({
+            items,
+            currency,
+            total,
+            customer,
+            shipping,
+        })
+
+        const payment = await createCloverPayment({
+            orderId: order.id,
+            total,
+            currency,
+        })
+
+        const transaction = {
+            orderId: order.id,
+            paymentId: payment.id,
+            status: payment.status || 'created',
+            cartHash,
+            amount: total,
+            createdAt: new Date().toISOString(),
+        }
+
+        await recordTransaction(transaction)
+
+        return NextResponse.json({
+            orderId: order.id,
+            paymentId: payment.id,
+            status: payment.status || 'created',
+            checkoutUrl:
+                payment.checkoutUrl || payment.approvalUrl || payment.href,
+            clientToken: payment.clientToken,
+        })
+    } catch (error) {
+        console.error('Checkout error', error)
+        return NextResponse.json(
+            {
+                error:
+                    error instanceof Error
+                        ? error.message
+                        : 'Checkout failed.',
+            },
+            { status: 400 }
+        )
+    }
+}
+
+async function handleWebhook(req: NextRequest) {
+    const rawBody = await req.text()
+    const signature = req.headers.get('x-clover-signature') || ''
+
+    if (
+        !verifyWebhookSignature(
+            rawBody,
+            signature,
+            cloverConfig.webhookSecret || ''
+        )
+    ) {
+        return NextResponse.json(
+            { error: 'Invalid signature' },
+            { status: 401 }
+        )
+    }
+
+    try {
+        const event = JSON.parse(rawBody)
+        const paymentId =
+            event?.payment?.id || event?.data?.id || event?.id || ''
+        const status = event?.payment?.status || event?.type || 'updated'
+
+        if (paymentId) {
+            await updateTransactionStatus(paymentId, status)
+        }
+
+        return NextResponse.json({ received: true })
+    } catch (error) {
+        return NextResponse.json(
+            { error: 'Invalid webhook payload' },
+            { status: 400 }
+        )
+    }
+}
+
+export async function POST(req: NextRequest) {
+    if (req.headers.get('x-clover-signature')) {
+        return handleWebhook(req)
+    }
+
+    return handleCheckout(req)
+}

--- a/components/CartPage.tsx
+++ b/components/CartPage.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react'
+import React, { useMemo, useState } from 'react'
 import { useCart } from '../hooks/useCart'
 
 /**
@@ -8,7 +8,25 @@ import { useCart } from '../hooks/useCart'
  * @return {JSX.Element|null} The cart page component or null if the page is not open.
  */
 export default function CartPage() {
-    const { cart, isPageOpen, closeCartPage, removeItem } = useCart()
+    const { cart, isPageOpen, closeCartPage, removeItem, submitCheckout } =
+        useCart()
+    const [customerName, setCustomerName] = useState('')
+    const [customerEmail, setCustomerEmail] = useState('')
+    const [shippingAddress, setShippingAddress] = useState({
+        line1: '',
+        line2: '',
+        city: '',
+        state: '',
+        postalCode: '',
+        country: 'US',
+    })
+    const [checkoutStatus, setCheckoutStatus] = useState<string | null>(null)
+    const [checkoutError, setCheckoutError] = useState<string | null>(null)
+
+    const formattedTotal = useMemo(
+        () => `${cart.currency || 'USD'} ${cart.total.toFixed(2)}`,
+        [cart.currency, cart.total]
+    )
 
     if (!isPageOpen) return null
 
@@ -83,11 +101,126 @@ export default function CartPage() {
                                 Subtotal
                             </p>
                             <p className="font-bold dark:text-white">
-                                ${cart.subtotal.toFixed(2)}
+                                {formattedTotal}
                             </p>
                         </div>
+                        <div className="space-y-3 rounded-xl border border-slate-200 bg-slate-50 p-3 text-sm dark:border-gray-700 dark:bg-gray-900">
+                            <div>
+                                <label className="block font-semibold text-slate-800 dark:text-white" htmlFor="checkout-name">
+                                    Customer name
+                                </label>
+                                <input
+                                    id="checkout-name"
+                                    value={customerName}
+                                    onChange={(e) => setCustomerName(e.target.value)}
+                                    className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+                                    placeholder="Full name"
+                                />
+                            </div>
+                            <div>
+                                <label className="block font-semibold text-slate-800 dark:text-white" htmlFor="checkout-email">
+                                    Email
+                                </label>
+                                <input
+                                    id="checkout-email"
+                                    type="email"
+                                    value={customerEmail}
+                                    onChange={(e) => setCustomerEmail(e.target.value)}
+                                    className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+                                    placeholder="you@example.com"
+                                />
+                            </div>
+                            <div>
+                                <label className="block font-semibold text-slate-800 dark:text-white" htmlFor="checkout-address">
+                                    Shipping address
+                                </label>
+                                <input
+                                    id="checkout-address"
+                                    value={shippingAddress.line1}
+                                    onChange={(e) =>
+                                        setShippingAddress((prev) => ({
+                                            ...prev,
+                                            line1: e.target.value,
+                                        }))
+                                    }
+                                    className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+                                    placeholder="Street address"
+                                />
+                            </div>
+                            <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+                                <input
+                                    value={shippingAddress.city}
+                                    onChange={(e) =>
+                                        setShippingAddress((prev) => ({
+                                            ...prev,
+                                            city: e.target.value,
+                                        }))
+                                    }
+                                    className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+                                    placeholder="City"
+                                />
+                                <input
+                                    value={shippingAddress.state}
+                                    onChange={(e) =>
+                                        setShippingAddress((prev) => ({
+                                            ...prev,
+                                            state: e.target.value,
+                                        }))
+                                    }
+                                    className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+                                    placeholder="State"
+                                />
+                                <input
+                                    value={shippingAddress.postalCode}
+                                    onChange={(e) =>
+                                        setShippingAddress((prev) => ({
+                                            ...prev,
+                                            postalCode: e.target.value,
+                                        }))
+                                    }
+                                    className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+                                    placeholder="ZIP"
+                                />
+                            </div>
+                        </div>
+                        {checkoutError && (
+                            <p className="text-sm text-red-600" role="alert">
+                                {checkoutError}
+                            </p>
+                        )}
+                        {checkoutStatus && (
+                            <p className="text-sm text-emerald-700 dark:text-emerald-300">
+                                {checkoutStatus}
+                            </p>
+                        )}
                         <button
                             type="button"
+                            onClick={async () => {
+                                setCheckoutError(null)
+                                setCheckoutStatus('Validating cart...')
+                                try {
+                                    const response = await submitCheckout({
+                                        customer: {
+                                            name: customerName || 'Guest',
+                                            email: customerEmail,
+                                        },
+                                        shipping: shippingAddress,
+                                    })
+
+                                    setCheckoutStatus('Redirecting to payment...')
+
+                                    if (response.checkoutUrl) {
+                                        window.location.href = response.checkoutUrl
+                                    }
+                                } catch (error) {
+                                    const message =
+                                        error instanceof Error
+                                            ? error.message
+                                            : 'Checkout failed.'
+                                    setCheckoutError(message)
+                                    setCheckoutStatus(null)
+                                }
+                            }}
                             className="inline-flex w-full items-center justify-center rounded-2xl bg-emerald-700 px-5 py-3 font-semibold text-white shadow hover:bg-emerald-800 focus:outline-none focus:ring-2 focus:ring-emerald-700 focus:ring-offset-2"
                         >
                             Checkout

--- a/lib/checkout-utils.mjs
+++ b/lib/checkout-utils.mjs
@@ -1,0 +1,95 @@
+import crypto from 'node:crypto'
+
+const asNumber = (value) => {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : NaN
+}
+
+export function validateCartPayload(payload) {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Invalid checkout payload')
+  }
+
+  const items = Array.isArray(payload.items) ? payload.items : []
+  if (items.length === 0) {
+    throw new Error('Cart items are required')
+  }
+
+  let currency = payload.currency || items[0]?.currency || 'USD'
+  let total = 0
+
+  for (const item of items) {
+    if (!item || typeof item !== 'object') {
+      throw new Error('Each item must be an object')
+    }
+    if (!item.variantId || !item.name) {
+      throw new Error('Item variantId and name are required')
+    }
+    const qty = asNumber(item.qty)
+    const price = asNumber(item.unitPrice)
+    if (!Number.isFinite(qty) || qty <= 0) {
+      throw new Error('Item quantities must be positive numbers')
+    }
+    if (!Number.isFinite(price) || price < 0) {
+      throw new Error('Item prices must be non-negative numbers')
+    }
+
+    total += price * qty
+    if (item.currency && !currency) {
+      currency = item.currency
+    }
+  }
+
+  total = Number(total.toFixed(2))
+  const providedTotal = asNumber(payload.total ?? payload.expectedTotal)
+  if (
+    Number.isFinite(providedTotal) &&
+    Math.abs(providedTotal - total) > 0.01
+  ) {
+    throw new Error('Cart total does not match calculated sum')
+  }
+
+  return {
+    items,
+    total,
+    currency,
+    customer: payload.customer || {},
+    shipping: payload.shipping || {},
+  }
+}
+
+export function verifyWebhookSignature(body, signature, secret) {
+  if (!secret || !signature) return false
+  const computed = crypto
+    .createHmac('sha256', secret)
+    .update(body)
+    .digest('hex')
+
+  const providedBuffer = Buffer.from(signature, 'hex')
+  const computedBuffer = Buffer.from(computed, 'hex')
+  if (providedBuffer.length !== computedBuffer.length) {
+    return false
+  }
+
+  return crypto.timingSafeEqual(providedBuffer, computedBuffer)
+}
+
+export function buildCartHash(payload) {
+  const normalized = {
+    items: Array.isArray(payload.items)
+      ? payload.items.map((item) => ({
+          variantId: item.variantId,
+          qty: item.qty,
+          price: item.unitPrice,
+        }))
+      : [],
+    total: payload.total,
+    customer: payload.customer || {},
+    shipping: payload.shipping || {},
+  }
+
+  return crypto
+    .createHash('sha256')
+    .update(JSON.stringify(normalized))
+    .digest('hex')
+}

--- a/lib/transaction-store.ts
+++ b/lib/transaction-store.ts
@@ -11,7 +11,11 @@ interface TransactionRecord {
     updatedAt?: string
 }
 
-const storePath = path.join(process.cwd(), 'data', 'transactions.json')
+const storePath =
+    process.env.TRANSACTION_STORE_PATH ||
+    (process.env.VERCEL
+        ? path.join('/tmp', 'transactions.json')
+        : path.join(process.cwd(), 'data', 'transactions.json'))
 
 async function readTransactions(): Promise<TransactionRecord[]> {
     try {
@@ -27,8 +31,12 @@ async function readTransactions(): Promise<TransactionRecord[]> {
 }
 
 async function writeTransactions(records: TransactionRecord[]) {
-    await fs.mkdir(path.dirname(storePath), { recursive: true })
-    await fs.writeFile(storePath, JSON.stringify(records, null, 2), 'utf8')
+    try {
+        await fs.mkdir(path.dirname(storePath), { recursive: true })
+        await fs.writeFile(storePath, JSON.stringify(records, null, 2), 'utf8')
+    } catch (error) {
+        console.error('Failed to write transactions', error)
+    }
 }
 
 export async function findTransactionByHash(

--- a/lib/transaction-store.ts
+++ b/lib/transaction-store.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+interface TransactionRecord {
+    orderId: string
+    paymentId?: string
+    status: string
+    cartHash: string
+    amount: number
+    createdAt: string
+    updatedAt?: string
+}
+
+const storePath = path.join(process.cwd(), 'data', 'transactions.json')
+
+async function readTransactions(): Promise<TransactionRecord[]> {
+    try {
+        const raw = await fs.readFile(storePath, 'utf8')
+        return JSON.parse(raw) as TransactionRecord[]
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return []
+        }
+        console.error('Failed to read transactions', error)
+        return []
+    }
+}
+
+async function writeTransactions(records: TransactionRecord[]) {
+    await fs.mkdir(path.dirname(storePath), { recursive: true })
+    await fs.writeFile(storePath, JSON.stringify(records, null, 2), 'utf8')
+}
+
+export async function findTransactionByHash(
+    cartHash: string
+): Promise<TransactionRecord | undefined> {
+    const records = await readTransactions()
+    return records.find((record) => record.cartHash === cartHash)
+}
+
+export async function recordTransaction(
+    record: TransactionRecord
+): Promise<TransactionRecord> {
+    const records = await readTransactions()
+    records.push(record)
+    await writeTransactions(records)
+    return record
+}
+
+export async function updateTransactionStatus(
+    paymentId: string,
+    status: string
+): Promise<void> {
+    const records = await readTransactions()
+    const record = records.find((entry) => entry.paymentId === paymentId)
+    if (!record) return
+
+    record.status = status
+    record.updatedAt = new Date().toISOString()
+    await writeTransactions(records)
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -75,6 +75,21 @@ const nextConfig: NextConfig = {
     }
     return buildId
   },
+
+  publicRuntimeConfig: {
+    clover: {
+      merchantId: process.env.CLOVER_MERCHANT_ID,
+    },
+  },
+  serverRuntimeConfig: {
+    clover: {
+      merchantId: process.env.CLOVER_MERCHANT_ID,
+      apiKey: process.env.CLOVER_API_KEY,
+      baseUrl: process.env.CLOVER_BASE_URL,
+      webhookSecret: process.env.CLOVER_WEBHOOK_SECRET,
+      allowedOrigins: process.env.CLOVER_ALLOWED_ORIGINS,
+    },
+  },
 }
 
 export default nextConfig

--- a/tests/checkout.test.mjs
+++ b/tests/checkout.test.mjs
@@ -1,0 +1,60 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import crypto from 'node:crypto'
+
+import {
+  validateCartPayload,
+  verifyWebhookSignature,
+  buildCartHash,
+} from '../lib/checkout-utils.mjs'
+
+test('validateCartPayload rejects mismatched totals', () => {
+  assert.throws(
+    () =>
+      validateCartPayload({
+        items: [
+          { variantId: 'a', name: 'Item', unitPrice: 10, qty: 1 },
+          { variantId: 'b', name: 'Item 2', unitPrice: 5, qty: 1 },
+        ],
+        total: 10,
+      }),
+    /total does not match/
+  )
+})
+
+test('validateCartPayload returns totals when valid', () => {
+  const payload = validateCartPayload({
+    items: [{ variantId: 'a', name: 'Item', unitPrice: 10, qty: 2 }],
+    total: 20,
+  })
+  assert.equal(payload.total, 20)
+  assert.equal(payload.currency, 'USD')
+  assert.equal(payload.items.length, 1)
+})
+
+test('verifyWebhookSignature checks hmac integrity', () => {
+  const secret = 'top-secret'
+  const body = JSON.stringify({ id: 'evt_123', data: {} })
+  const signature = crypto
+    .createHmac('sha256', secret)
+    .update(body)
+    .digest('hex')
+
+  assert.equal(verifyWebhookSignature(body, signature, secret), true)
+  assert.equal(verifyWebhookSignature(body, 'bad', secret), false)
+})
+
+test('buildCartHash is deterministic', () => {
+  const first = buildCartHash({
+    items: [{ variantId: 'a', qty: 1, unitPrice: 5 }],
+    customer: { email: 'a@example.com' },
+    shipping: { line1: '123 Main' },
+  })
+  const second = buildCartHash({
+    items: [{ variantId: 'a', qty: 1, unitPrice: 5 }],
+    customer: { email: 'a@example.com' },
+    shipping: { line1: '123 Main' },
+  })
+
+  assert.equal(first, second)
+})

--- a/types/cart.ts
+++ b/types/cart.ts
@@ -1,0 +1,39 @@
+export interface CartItem {
+    productId: string
+    variantId: string
+    name: string
+    image: string
+    unitPrice: number
+    currency: string
+    qty: number
+}
+
+export interface Cart {
+    items: CartItem[]
+    subtotal: number
+    total: number
+    currency: string
+}
+
+export interface CheckoutCustomer {
+    name: string
+    email?: string
+    phone?: string
+}
+
+export interface ShippingAddress {
+    line1: string
+    line2?: string
+    city: string
+    state: string
+    postalCode: string
+    country?: string
+}
+
+export interface CheckoutResponse {
+    orderId: string
+    paymentId?: string
+    checkoutUrl?: string
+    clientToken?: string
+    status: string
+}


### PR DESCRIPTION
## Summary
- add Clover checkout API route with HTTPS/origin enforcement, cart validation, and webhook signature handling
- persist transaction hashes for idempotent lookups and store Clover order/payment identifiers
- extend cart UI to collect customer/shipping details and submit to the new checkout endpoint

## Testing
- node --test --test-reporter=spec tests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed1cf5ff88329a6d87cd71879da0b)